### PR TITLE
Fixed quoting of raw string literals.

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -315,6 +315,19 @@ bool isNameChar(unsigned char ch) {
     return std::isalnum(ch) || ch == '_' || ch == '$';
 }
 
+static std::string escapeString(const std::string &str) {
+    std::ostringstream ostr;
+    ostr << '"';
+    for (std::size_t i = 1U; i < str.size() - 1; ++i) {
+      char c = str[i];
+      if (c == '\\' || c == '"')
+          ostr << '\\';
+      ostr << c;
+    }
+    ostr << '"';
+    return ostr.str();
+}
+
 void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filename, OutputList *outputList)
 {
     std::stack<simplecpp::Location> loc;
@@ -444,7 +457,7 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                     // TODO report
                     return;
                 currentToken.erase(currentToken.size() - endOfRawString.size(), endOfRawString.size() - 1U);
-                back()->setstr(currentToken);
+                back()->setstr(escapeString(currentToken));
                 location.col += currentToken.size() + 2U + 2 * delim.size();
                 continue;
             }

--- a/test.cpp
+++ b/test.cpp
@@ -758,8 +758,11 @@ void readfile_string() {
 }
 
 void readfile_rawstring() {
-    ASSERT_EQUALS("A = \"abc\\\\def\"", readfile("A = R\"(abc\\\\def)\""));
-    ASSERT_EQUALS("A = \"abc\\\\def\"", readfile("A = R\"x(abc\\\\def)x\""));
+    ASSERT_EQUALS("A = \"abc\\\\\\\\def\"", readfile("A = R\"(abc\\\\def)\""));
+    ASSERT_EQUALS("A = \"abc\\\\\\\\def\"", readfile("A = R\"x(abc\\\\def)x\""));
+    ASSERT_EQUALS("A = \"\"", readfile("A = R\"()\""));
+    ASSERT_EQUALS("A = \"\\\\\"", readfile("A = R\"(\\)\""));
+    ASSERT_EQUALS("A = \"\\\"\"", readfile("A = R\"(\")\""));
 }
 
 void tokenMacro1() {


### PR DESCRIPTION
Although raw string literals are correctly parsed, their actual content is wrong: If I read the code in the simplecpp and cppcheck projects correctly, the intention is that the raw string literals are converted to normal string literals. To do this, one must escape special chars in the raw string literal, which is exactly what is done in this patch. Another approach would be keeping the raw string literals as they are, but I think cppcheck would need some changes then, too.

The fix needs to be pushed to cppcheck's copy, too, otherwise it gets the following code wrong:

```C++
static void bar(const char*) {}
static void baz(int) {}
int main() {
  bar(R"(")");
  baz(123);
  bar(R"(")");
}
```

Without the patch, cppcheck incorrectly complains about `baz` being never used. I guess what's going on is as follows: simplecpp doesn't quote the resulting strings correctly, so cppcheck actually sees 3 consecutive string literals, the middle one being the call to `baz`. :stuck_out_tongue: 