### PR TITLE
Allow usage of user-specific compiler and linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 all:	testrunner	simplecpp
 
-testrunner:	test.cpp	simplecpp.o
-	$(CXX) -Wall -Wextra -pedantic -g -std=c++0x simplecpp.o test.cpp -o testrunner
+testrunner:	test.o	simplecpp.o
+	$(CXX) $(LDFLAGS) simplecpp.o test.o -o testrunner
+	
+test.o:	test.cpp
+	$(CXX) $(CXXFLAGS) -Wall -Wextra -pedantic -g -std=c++0x -c test.cpp
 
 simplecpp.o:	simplecpp.cpp	simplecpp.h
-	$(CXX) -Wall -Wextra -pedantic -g -std=c++0x -c simplecpp.cpp
+	$(CXX) $(CXXFLAGS) -Wall -Wextra -pedantic -g -std=c++0x -c simplecpp.cpp
 
 test:	testrunner	simplecpp
 	g++ -fsyntax-only simplecpp.cpp && ./testrunner && python run-tests.py
@@ -13,4 +16,4 @@ simplecpp:	main.cpp	simplecpp.o
 	$(CXX) -Wall -g -std=c++0x main.cpp simplecpp.o -o simplecpp
 
 clean:
-	rm testrunner simplecpp simplecpp.o
+	rm -f testrunner simplecpp *.o


### PR DESCRIPTION
This change allows usage of CXXFLAGS and LDFLAGS - so far at least in addition to the still hardcoded ones.