### PR TITLE
Fix #46, add Linux binary files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 *.exe
 *.out
 *.app
+simplecpp
+testrunner

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1640,7 +1640,13 @@ void simplifySizeof(simplecpp::TokenList &expr, const std::map<std::string, std:
         if (tok->str != "sizeof")
             continue;
         simplecpp::Token *tok1 = tok->next;
+        if (!tok1) {
+            throw std::runtime_error("missed sizeof argument");
+        }
         simplecpp::Token *tok2 = tok1->next;
+        if (!tok2) {
+            throw std::runtime_error("missed sizeof argument");
+        }
         if (tok1->op == '(') {
             tok1 = tok1->next;
             while (tok2->op != ')')


### PR DESCRIPTION
Result on example from #46:

    input.c:1: syntax error: failed to evaluate #if condition

With cppcheck:

    Checking input.c ...
    [./input.c:1]: (error) failed to evaluate #if condition