### PR TITLE
Fix corner cases in simplifyPath()

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1741,9 +1741,10 @@ namespace simplecpp {
         pos = 1U;
         while ((pos = path.find("/../", pos)) != std::string::npos) {
             const std::string::size_type pos1 = path.rfind('/', pos - 1U);
-            if (pos1 == std::string::npos)
-                pos++;
-            else {
+            if (pos1 == std::string::npos) {
+                path.erase(0,pos+4);
+                pos = 0;
+            } else {
                 path.erase(pos1,pos-pos1+3);
                 pos = std::min((std::string::size_type)1, pos1);
             }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1727,14 +1727,13 @@ namespace simplecpp {
         // replace backslash separators
         std::replace(path.begin(), path.end(), '\\', '/');
 
-        // "./" at the start
-        if (path.size() > 3 && path.compare(0,2,"./") == 0 && path[2] != '/')
-            path.erase(0,2);
-
-        // remove "/./"
+        // remove "./"
         pos = 0;
-        while ((pos = path.find("/./",pos)) != std::string::npos) {
-            path.erase(pos,2);
+        while ((pos = path.find("./",pos)) != std::string::npos) {
+            if (pos == 0 || path[pos - 1U] == '/')
+                path.erase(pos,2);
+            else
+                pos += 2;
         }
 
         // remove "xyz/../"

--- a/test.cpp
+++ b/test.cpp
@@ -1239,9 +1239,17 @@ namespace simplecpp {
 void simplifyPath()
 {
     ASSERT_EQUALS("1.c", simplecpp::simplifyPath("./1.c"));
+    ASSERT_EQUALS("1.c", simplecpp::simplifyPath("a/../1.c"));
+    ASSERT_EQUALS("1.c", simplecpp::simplifyPath("a/b/../../1.c"));
+    ASSERT_EQUALS("a/1.c", simplecpp::simplifyPath("a/b/../1.c"));
     ASSERT_EQUALS("/a/1.c", simplecpp::simplifyPath("/a/b/../1.c"));
     ASSERT_EQUALS("/a/1.c", simplecpp::simplifyPath("/a/b/c/../../1.c"));
     ASSERT_EQUALS("/a/1.c", simplecpp::simplifyPath("/a/b/c/../.././1.c"));
+
+    ASSERT_EQUALS("../1.c", simplecpp::simplifyPath("../1.c"));
+    ASSERT_EQUALS("../1.c", simplecpp::simplifyPath("../a/../1.c"));
+    ASSERT_EQUALS("/../1.c", simplecpp::simplifyPath("/../1.c"));
+    ASSERT_EQUALS("/../1.c", simplecpp::simplifyPath("/../a/../1.c"));
 }
 
 

--- a/test.cpp
+++ b/test.cpp
@@ -1239,6 +1239,11 @@ namespace simplecpp {
 void simplifyPath()
 {
     ASSERT_EQUALS("1.c", simplecpp::simplifyPath("./1.c"));
+    ASSERT_EQUALS("1.c", simplecpp::simplifyPath("././1.c"));
+    ASSERT_EQUALS("/1.c", simplecpp::simplifyPath("/./1.c"));
+    ASSERT_EQUALS("/1.c", simplecpp::simplifyPath("/././1.c"));
+    ASSERT_EQUALS("trailing_dot./1.c", simplecpp::simplifyPath("trailing_dot./1.c"));
+
     ASSERT_EQUALS("1.c", simplecpp::simplifyPath("a/../1.c"));
     ASSERT_EQUALS("1.c", simplecpp::simplifyPath("a/b/../../1.c"));
     ASSERT_EQUALS("a/1.c", simplecpp::simplifyPath("a/b/../1.c"));


### PR DESCRIPTION
This PR fixes 2 issues:
1. `dir/../` wasn't simplified away when it was located at the path start. This lead to non-simplified paths in cppcheck report for errors in headers included like that: `#include "../foo.h"` First patch fixes that.
2. Only one instance of `./` was removed from the path start. Second patch fixes that.

There is also a case when `dir//../` would be incorrectly simplified to `dir/`. This could be fixed either by replacing all consecutive slashes with one slash everywhere or by starting search for a slash from the first non-slash before the matched `/../`. I think first solution would be much cleaner, what would you prefer?