### PR TITLE
Sync simplecpp::simplifyPath() with cppcheck's Path::simplifyPath()

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1724,10 +1724,30 @@ namespace simplecpp {
      */
     std::string simplifyPath(std::string path)
     {
+        const bool isUnc = path.compare(0,2,"//") == 0;
+
+        // Remove ./, .//, ./// etc. at the beginning
+        while (path.compare(0,2,"./") == 0) { // remove "./././"
+            const size_t toErase = path.find_first_not_of('/', 2);
+            path = path.erase(0, toErase);
+        }
         std::string::size_type pos;
 
         // replace backslash separators
         std::replace(path.begin(), path.end(), '\\', '/');
+
+        // replace double slash
+        // First filter out all double slashes
+        for (std::string::iterator it=path.begin(); it!=path.end(); ++it) {
+            if (*it=='/') {
+                std::string::iterator next=it+1;
+                while (next!=path.end() && *next=='/') {
+                    next=path.erase(next);
+                }
+
+            }
+
+        }
 
         // remove "./"
         pos = 0;
@@ -1751,6 +1771,10 @@ namespace simplecpp {
             }
         }
 
+        if (isUnc) {
+            // Restore the leading double slash
+            path.insert(path.begin(), '/');
+        }
         return realFilename(path);
     }
 }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1807,7 +1807,7 @@ namespace simplecpp {
         // replace backslash separators
         std::replace(path.begin(), path.end(), '\\', '/');
         // detect: DOS/Windows path including drive letter
-        const bool isAbsolute=path.front()=='/' || DOSDriveLetterPathAbsolute(path);
+        const bool isAbsolute=path[0]=='/' || DOSDriveLetterPathAbsolute(path);
         // Trailing slash indicates a directory is specified
         const bool hasTrailingSlash=path[path.length()-1]=='/';
 

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -294,6 +294,13 @@ namespace simplecpp {
      * Deallocate data
      */
     SIMPLECPP_LIB void cleanup(std::map<std::string, TokenList*> &filedata);
+
+    /**
+     * Simplify path: "." and ".." are resolved, path separator is "/"
+     * @param path Path to be normalized.
+     * \return normalized path
+     * */
+    SIMPLECPP_LIB std::string simplifyPath(const std::string path);
 }
 
 #endif

--- a/test.cpp
+++ b/test.cpp
@@ -1321,15 +1321,15 @@ void simplifyPath_cppcheck()
     ASSERT_EQUALS("/index.h", simplecpp::simplifyPath("/path/../other///././..///index.h"));
     ASSERT_EQUALS("../path/index.h", simplecpp::simplifyPath("../path/other/../index.h"));
     ASSERT_EQUALS("a/index.h", simplecpp::simplifyPath("a/../a/index.h"));
-    ASSERT_EQUALS("a/..", simplecpp::simplifyPath("a/.."));
-    ASSERT_EQUALS("a/..", simplecpp::simplifyPath("./a/.."));
+    ASSERT_EQUALS(".", simplecpp::simplifyPath("a/.."));
+    ASSERT_EQUALS(".", simplecpp::simplifyPath("./a/.."));
     ASSERT_EQUALS("../../src/test.cpp", simplecpp::simplifyPath("../../src/test.cpp"));
     ASSERT_EQUALS("../../../src/test.cpp", simplecpp::simplifyPath("../../../src/test.cpp"));
     ASSERT_EQUALS("src/test.cpp", simplecpp::simplifyPath(".//src/test.cpp"));
     ASSERT_EQUALS("src/test.cpp", simplecpp::simplifyPath(".///src/test.cpp"));
     ASSERT_EQUALS("test.cpp", simplecpp::simplifyPath("./././././test.cpp"));
-    TODO_ASSERT_EQUALS("src", "src/abc/..", simplecpp::simplifyPath("src/abc/.."));
-    ASSERT_EQUALS("src", simplecpp::simplifyPath("src/abc/../"));
+    ASSERT_EQUALS("src", simplecpp::simplifyPath("src/abc/.."));
+    ASSERT_EQUALS("src/", simplecpp::simplifyPath("src/abc/../"));
 
     // Handling of UNC paths on Windows
     ASSERT_EQUALS("//src/test.cpp", simplecpp::simplifyPath("//src/test.cpp"));


### PR DESCRIPTION
As suggested this PR aims to synchronize the simplifyPath() routine from cppcheck and simplecpp.

So far tests from cppcheck have been imported to simplecpp, a few have been added on top. Currently on Linux 4 are still failing, number on Windows is unknown and will be addressed later.