### PR TITLE
Ensure valueToken is assigned in Macro::parseDefine

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1196,6 +1196,7 @@ namespace simplecpp {
                 }
                 if (!sameline(nametoken, argtok)) {
                     endToken = argtok ? argtok->previous : argtok;
+                    valueToken = NULL;
                     return false;
                 }
                 valueToken = argtok ? argtok->next : NULL;


### PR DESCRIPTION
This resolves https://github.com/danmar/simplecpp/issues/97