### PR TITLE
Cast result of istream::get() uniformly with surrounding code

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -338,7 +338,7 @@ static unsigned short getAndSkipBOM(std::istream &istr)
 
     // Skip UTF-8 BOM 0xefbbbf
     if (ch1 == 0xef) {
-        istr.get();
+        (void)istr.get();
         if (istr.get() == 0xbb && istr.peek() == 0xbf) {
             (void)istr.get();
         } else {


### PR DESCRIPTION
All other such calls have a cast (most likely to avoid "return value not used" static analysis complaints). This line is as good as those other lines.