### PR TITLE
Improve performance on windows

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -35,7 +35,6 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW32__)
 #include <windows.h>
-#include <VersionHelpers.h>
 #undef ERROR
 #undef TRUE
 #define SIMPLECPP_WINDOWS
@@ -1750,11 +1749,7 @@ static bool realFileName(const std::string &f, std::string *result)
     WIN32_FIND_DATAA FindFileData;
 	HANDLE hFind = INVALID_HANDLE_VALUE;
 	// only fetch once
-	static BOOL bIsWindows7OrGreater = IsWindows7OrGreater();
-	if (bIsWindows7OrGreater)
-		hFind = FindFirstFileExA(f.c_str(), FindExInfoBasic, &FindFileData, FindExSearchNameMatch, NULL, 0);
-	else
-		hFind = FindFirstFileA(f.c_str(), &FindFileData);
+	hFind = FindFirstFileExA(f.c_str(), FindExInfoBasic, &FindFileData, FindExSearchNameMatch, NULL, 0);
 
     if (INVALID_HANDLE_VALUE == hFind)
         return false;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1747,9 +1747,7 @@ static bool realFileName(const std::string &f, std::string *result)
 
     // Lookup filename or foldername on file system
     WIN32_FIND_DATAA FindFileData;
-	HANDLE hFind = INVALID_HANDLE_VALUE;
-	// only fetch once
-	hFind = FindFirstFileExA(f.c_str(), FindExInfoBasic, &FindFileData, FindExSearchNameMatch, NULL, 0);
+	HANDLE hFind = FindFirstFileExA(f.c_str(), FindExInfoBasic, &FindFileData, FindExSearchNameMatch, NULL, 0);
 
     if (INVALID_HANDLE_VALUE == hFind)
         return false;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1831,6 +1831,9 @@ namespace simplecpp {
      */
     std::string simplifyPath(std::string path)
     {
+        if (path.empty())
+            return path;
+
         std::string::size_type pos;
 
         // replace backslash separators

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -35,6 +35,7 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW32__)
 #include <windows.h>
+#include <VersionHelpers.h>
 #undef ERROR
 #undef TRUE
 #define SIMPLECPP_WINDOWS
@@ -1752,8 +1753,15 @@ static bool realFileName(const std::string &f, std::string *result)
 
     // Lookup filename or foldername on file system
     WIN32_FIND_DATAA FindFileData;
-    HANDLE hFind = FindFirstFileA(&buf[0], &FindFileData);
-    if (hFind == INVALID_HANDLE_VALUE)
+	HANDLE hFind = INVALID_HANDLE_VALUE;
+	// only fetch once
+	static BOOL bIsWindows7OrGreater = IsWindows7OrGreater();
+	if (bIsWindows7OrGreater)
+		hFind = FindFirstFileExA(&buf[0], FindExInfoBasic, &FindFileData, FindExSearchNameMatch, NULL, 0);
+	else
+		hFind = FindFirstFileA(&buf[0], &FindFileData);
+
+    if (INVALID_HANDLE_VALUE == hFind)
         return false;
     *result = FindFileData.cFileName;
     FindClose(hFind);

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2031,6 +2031,9 @@ static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const
 
 static std::string getFileName(const std::map<std::string, simplecpp::TokenList *> &filedata, const std::string &sourcefile, const std::string &header, const simplecpp::DUI &dui, bool systemheader)
 {
+	if (filedata.empty()) {
+		return "";
+	}
     if (isAbsolutePath(header)) {
         return (filedata.find(header) != filedata.end()) ? simplecpp::simplifyPath(header) : "";
     }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1746,20 +1746,15 @@ static bool realFileName(const std::string &f, std::string *result)
     if (!alpha)
         return false;
 
-    // Convert char path to CHAR path
-    std::vector<CHAR> buf(f.size()+1U, 0);
-    for (unsigned int i = 0; i < f.size(); ++i)
-        buf[i] = f[i];
-
     // Lookup filename or foldername on file system
     WIN32_FIND_DATAA FindFileData;
 	HANDLE hFind = INVALID_HANDLE_VALUE;
 	// only fetch once
 	static BOOL bIsWindows7OrGreater = IsWindows7OrGreater();
 	if (bIsWindows7OrGreater)
-		hFind = FindFirstFileExA(&buf[0], FindExInfoBasic, &FindFileData, FindExSearchNameMatch, NULL, 0);
+		hFind = FindFirstFileExA(f.c_str(), FindExInfoBasic, &FindFileData, FindExSearchNameMatch, NULL, 0);
 	else
-		hFind = FindFirstFileA(&buf[0], &FindFileData);
+		hFind = FindFirstFileA(f.c_str(), &FindFileData);
 
     if (INVALID_HANDLE_VALUE == hFind)
         return false;


### PR DESCRIPTION
by using the [faster ](https://ariccio.com/2015/01/13/how-fast-are-findfirstfilefindfirstfileex-and-cfilefind-actually/) FindFirstFileEx with `FindExInfoBasic` since not more is required at that spot.

Also return from `getFileName()` early if the haystack `filedata` is empty. The function is within the top 10 of CPU time consumers when running against a fairly large codebase and measuring with Visual Studio 2017 Performance Analysis.

Both improvements have led to an analysis time decrease of between 5% (solution with 14 projects, 3022 files to check) and 15% (solution with 645 projects, 21714 files to check).

