### PR TITLE
Cache results of FindFirstFileExA to improve performance on Windows

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1880,7 +1880,7 @@ public:
         CloseHandle(m_mutex);
     }
 
-    bool getRealPathFromCache(std::string const& path, std::string* returnPath)
+    bool getRealPathFromCache(const std::string& path, std::string* returnPath)
     {
         ScopedLock lock(m_mutex);
 


### PR DESCRIPTION
This adds a cache to the realFileName call to improve performance of check times on Windows. 
Prior to this change, cppcheck was taking 30 minutes to run on a codebase consisting of 87 solutions, 594 projects and 18000 files (using -j8). 
After this change, cppcheck now takes 12.7 minutes (-j8). 

We have been using cppcheck 1.85 with this change since October last year without issues in our nightly. 

![image](https://user-images.githubusercontent.com/29177461/51724612-2f782980-2099-11e9-9eb8-dc064e6a431d.png)

