### PR TITLE
Use realFileNameMap cache also in outer realFilename function 

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1945,6 +1945,8 @@ static std::string realFilename(const std::string &f)
 {
     std::string ret;
     ret.reserve(f.size()); // this will be the final size
+    if (realFileNameMap.getRealPathFromCache(f, &ret))
+      return ret;
 
     // Current subpath
     std::string subpath;
@@ -1984,6 +1986,7 @@ static std::string realFilename(const std::string &f)
             ret += subpath;
     }
 
+    realFileNameMap.addToCache(f, ret);
     return ret;
 }
 

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1744,11 +1744,17 @@ namespace simplecpp {
                 throw invalidHashHash(tok->location, name());
             if (!sameline(tok, tok->next) || !sameline(tok, tok->next->next))
                 throw invalidHashHash(tok->location, name());
-            if (!A->name && !A->number && A->op != ',' && !A->str().empty())
+
+            bool canBeConcatenatedWithEqual = A->isOneOf("+-*/%&|^") || A->str() == "<<" || A->str() == ">>";
+            if (!A->name && !A->number && A->op != ',' && !A->str().empty() && !canBeConcatenatedWithEqual)
                 throw invalidHashHash(tok->location, name());
 
             Token *B = tok->next->next;
-            if (!B->name && !B->number && B->op && B->op != '#')
+            if (!B->name && !B->number && B->op && !B->isOneOf("#="))
+                throw invalidHashHash(tok->location, name());
+
+            if ((canBeConcatenatedWithEqual && B->op != '=') ||
+                (!canBeConcatenatedWithEqual && B->op == '='))
                 throw invalidHashHash(tok->location, name());
 
             std::string strAB;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -329,13 +329,14 @@ static void ungetChar(std::istream &istr, unsigned int bom)
 
 static unsigned short getAndSkipBOM(std::istream &istr)
 {
-    const unsigned char ch1 = istr.peek();
+    const int ch1 = istr.peek();
 
     // The UTF-16 BOM is 0xfffe or 0xfeff.
     if (ch1 >= 0xfe) {
         unsigned short bom = ((unsigned char)istr.get() << 8);
         if (istr.peek() >= 0xfe)
             return bom | (unsigned char)istr.get();
+        istr.unget();
         return 0;
     }
 

--- a/test.cpp
+++ b/test.cpp
@@ -644,6 +644,54 @@ static void hashhash8()
     ASSERT_EQUALS("\nxy = 123 ;", preprocess(code));
 }
 
+static void hashhash9()
+{
+    const char * code = "#define ADD_OPERATOR(OP) void operator OP ## = (void) { x = x OP 1; }\n"
+                        "ADD_OPERATOR(+);\n"
+                        "ADD_OPERATOR(-);\n"
+                        "ADD_OPERATOR(*);\n"
+                        "ADD_OPERATOR(/);\n"
+                        "ADD_OPERATOR(%);\n"
+                        "ADD_OPERATOR(&);\n"
+                        "ADD_OPERATOR(|);\n"
+                        "ADD_OPERATOR(^);\n"
+                        "ADD_OPERATOR(<<);\n"
+                        "ADD_OPERATOR(>>);\n";
+    const char expected[] = "\n"
+                            "void operator += ( void ) { x = x + 1 ; } ;\n"
+                            "void operator -= ( void ) { x = x - 1 ; } ;\n"
+                            "void operator *= ( void ) { x = x * 1 ; } ;\n"
+                            "void operator /= ( void ) { x = x / 1 ; } ;\n"
+                            "void operator %= ( void ) { x = x % 1 ; } ;\n"
+                            "void operator &= ( void ) { x = x & 1 ; } ;\n"
+                            "void operator |= ( void ) { x = x | 1 ; } ;\n"
+                            "void operator ^= ( void ) { x = x ^ 1 ; } ;\n"
+                            "void operator <<= ( void ) { x = x << 1 ; } ;\n"
+                            "void operator >>= ( void ) { x = x >> 1 ; } ;";
+    ASSERT_EQUALS(expected, preprocess(code));
+
+    const simplecpp::DUI dui;
+    simplecpp::OutputList outputList;
+
+    code = "#define A +##x\n"
+           "A";
+    outputList.clear();
+    preprocess(code, dui, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'A', Invalid ## usage when expanding 'A'.\n", toString(outputList));
+
+    code = "#define A 2##=\n"
+           "A";
+    outputList.clear();
+    preprocess(code, dui, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'A', Invalid ## usage when expanding 'A'.\n", toString(outputList));
+
+    code = "#define A <<##x\n"
+           "A";
+    outputList.clear();
+    preprocess(code, dui, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'A', Invalid ## usage when expanding 'A'.\n", toString(outputList));
+}
+
 static void hashhash_invalid_1()
 {
     std::istringstream istr("#define  f(a)  (##x)\nf(1)");
@@ -1636,6 +1684,7 @@ int main(int argc, char **argv)
     TEST_CASE(hashhash6);
     TEST_CASE(hashhash7); // # ## #  (C standard; 6.10.3.3.p4)
     TEST_CASE(hashhash8);
+    TEST_CASE(hashhash9);
     TEST_CASE(hashhash_invalid_1);
     TEST_CASE(hashhash_invalid_2);
 


### PR DESCRIPTION
This further improves "real file name" caching by letting the outer function realFilename(const std::string &f) access the same cache as the inner function realFileName(const std::string &f, std::string *result)

Cppcheck runtime with earlier PR #145 applied: 31 mins
Cppcheck runtime with both PRs applied: 13.7 mins (-55.8%)
Both using -j24 on my large solution (see PR #144).

@danmar In your review for PR #144 you stated:
> I should have been more worried about it before .. but I am not sure that this will work for relative paths. The path "foo/src.cpp" might be "Foo/Src.cpp" in one folder and "foo/srC.cpp" in another folder.

As I see it, getting the real case-sensitive file name (Windows only) for relative paths usually cannot succeed anyway (FindFirstFileExA returns INVALID_HANDLE_VALUE): There is no defined base path for resolving the relative path against. Instead, the current working directory of the Cppcheck process is taken as base path (which is probably not what we want). So calling realFilename for relative paths is highly questionable.

However, when resolving relative #includes in cpp files, getting the real file name already works correctly, because getFileName and openHeader always specify a base path.