### PR TITLE
Fix ## of assignement operators. Fixes #141

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1744,11 +1744,17 @@ namespace simplecpp {
                 throw invalidHashHash(tok->location, name());
             if (!sameline(tok, tok->next) || !sameline(tok, tok->next->next))
                 throw invalidHashHash(tok->location, name());
-            if (!A->name && !A->number && A->op != ',' && !A->str().empty())
+
+            bool canBeConcatenatedWithEqual = A->isOneOf("+-*/%&|^") || A->str() == "<<" || A->str() == ">>";
+            if (!A->name && !A->number && A->op != ',' && !A->str().empty() && !canBeConcatenatedWithEqual)
                 throw invalidHashHash(tok->location, name());
 
             Token *B = tok->next->next;
-            if (!B->name && !B->number && B->op && B->op != '#')
+            if (!B->name && !B->number && B->op && !B->isOneOf("#="))
+                throw invalidHashHash(tok->location, name());
+
+            if ((canBeConcatenatedWithEqual && B->op != '=') ||
+                (!canBeConcatenatedWithEqual && B->op == '='))
                 throw invalidHashHash(tok->location, name());
 
             std::string strAB;

--- a/test.cpp
+++ b/test.cpp
@@ -644,6 +644,54 @@ static void hashhash8()
     ASSERT_EQUALS("\nxy = 123 ;", preprocess(code));
 }
 
+static void hashhash9()
+{
+    const char * code = "#define ADD_OPERATOR(OP) void operator OP ## = (void) { x = x OP 1; }\n"
+                        "ADD_OPERATOR(+);\n"
+                        "ADD_OPERATOR(-);\n"
+                        "ADD_OPERATOR(*);\n"
+                        "ADD_OPERATOR(/);\n"
+                        "ADD_OPERATOR(%);\n"
+                        "ADD_OPERATOR(&);\n"
+                        "ADD_OPERATOR(|);\n"
+                        "ADD_OPERATOR(^);\n"
+                        "ADD_OPERATOR(<<);\n"
+                        "ADD_OPERATOR(>>);\n";
+    const char expected[] = "\n"
+                            "void operator += ( void ) { x = x + 1 ; } ;\n"
+                            "void operator -= ( void ) { x = x - 1 ; } ;\n"
+                            "void operator *= ( void ) { x = x * 1 ; } ;\n"
+                            "void operator /= ( void ) { x = x / 1 ; } ;\n"
+                            "void operator %= ( void ) { x = x % 1 ; } ;\n"
+                            "void operator &= ( void ) { x = x & 1 ; } ;\n"
+                            "void operator |= ( void ) { x = x | 1 ; } ;\n"
+                            "void operator ^= ( void ) { x = x ^ 1 ; } ;\n"
+                            "void operator <<= ( void ) { x = x << 1 ; } ;\n"
+                            "void operator >>= ( void ) { x = x >> 1 ; } ;";
+    ASSERT_EQUALS(expected, preprocess(code));
+
+    const simplecpp::DUI dui;
+    simplecpp::OutputList outputList;
+
+    code = "#define A +##x\n"
+           "A";
+    outputList.clear();
+    preprocess(code, dui, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'A', Invalid ## usage when expanding 'A'.\n", toString(outputList));
+
+    code = "#define A 2##=\n"
+           "A";
+    outputList.clear();
+    preprocess(code, dui, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'A', Invalid ## usage when expanding 'A'.\n", toString(outputList));
+
+    code = "#define A <<##x\n"
+           "A";
+    outputList.clear();
+    preprocess(code, dui, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'A', Invalid ## usage when expanding 'A'.\n", toString(outputList));
+}
+
 static void hashhash_invalid_1()
 {
     std::istringstream istr("#define  f(a)  (##x)\nf(1)");
@@ -1636,6 +1684,7 @@ int main(int argc, char **argv)
     TEST_CASE(hashhash6);
     TEST_CASE(hashhash7); // # ## #  (C standard; 6.10.3.3.p4)
     TEST_CASE(hashhash8);
+    TEST_CASE(hashhash9);
     TEST_CASE(hashhash_invalid_1);
     TEST_CASE(hashhash_invalid_2);
 


### PR DESCRIPTION
Previously, simplecpp would throw an error for invalid usage of ## for
the following code:

    #define ADD_OPERATOR(OP) void operator OP ## = (void) { x = x OP 1; }
    ADD_OPERATOR(+)

This commit allows the above macro work with all allowed c and c++
compound assignment operators.

Note that

     #define A < ## < ## =
     A

will still throw an error.