### PR TITLE
Minor fixes to getAndSkipBOM()

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -329,13 +329,14 @@ static void ungetChar(std::istream &istr, unsigned int bom)
 
 static unsigned short getAndSkipBOM(std::istream &istr)
 {
-    const unsigned char ch1 = istr.peek();
+    const int ch1 = istr.peek();
 
     // The UTF-16 BOM is 0xfffe or 0xfeff.
     if (ch1 >= 0xfe) {
         unsigned short bom = ((unsigned char)istr.get() << 8);
         if (istr.peek() >= 0xfe)
             return bom | (unsigned char)istr.get();
+        istr.unget();
         return 0;
     }
 


### PR DESCRIPTION
Add a missing call to istream.unget() in case the file starts with 0xfe
or 0xff but does not continue with 0xff. This makes simplecpp abort
parsing immediately on such files, instead of silently ignoring the first
character and continue parsing.

Also, save return value of istream.peek() as int. If the file is empty,
istream.peek() returns EOF (a negative int value, typically -1).
It was silently converted to unsigned char, which made it take a
somewhat unintentional path before returning. Note that there was no
erroneous parsing, or undefined behaviour. Fixes #133.
