### PR TITLE
Use realFileNameMap cache also in outer realFilename function

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1945,6 +1945,8 @@ static std::string realFilename(const std::string &f)
 {
     std::string ret;
     ret.reserve(f.size()); // this will be the final size
+    if (realFileNameMap.getRealPathFromCache(f, &ret))
+      return ret;
 
     // Current subpath
     std::string subpath;
@@ -1984,6 +1986,7 @@ static std::string realFilename(const std::string &f)
             ret += subpath;
     }
 
+    realFileNameMap.addToCache(f, ret);
     return ret;
 }
 


### PR DESCRIPTION
2nd try (replacing 1st try #146):

This further improves "real file name" caching by letting the outer function realFilename(const std::string &f) access the same cache as the inner function realFileName(const std::string &f, std::string *result)

Cppcheck runtime with earlier PR #145 applied: 31 mins
Cppcheck runtime with both PRs applied: 13.7 mins (-55.8%)
Both using -j24 on my large solution (see PR #144).

@danmar In your review for PR #144 you stated:
> I should have been more worried about it before .. but I am not sure that this will work for relative paths. The path "foo/src.cpp" might be "Foo/Src.cpp" in one folder and "foo/srC.cpp" in another folder.

As I see it, getting the real case-sensitive file name (Windows only) for relative paths usually cannot succeed anyway (FindFirstFileExA returns INVALID_HANDLE_VALUE): There is no defined base path for resolving the relative path against. Instead, the current working directory of the Cppcheck process is taken as base path (which is probably not what we want). So calling realFilename for relative paths is highly questionable.

However, when resolving relative #includes in cpp files, getting the real file name already works correctly, because getFileName and openHeader always specify a base path.