### PR TITLE
Cache non-existing header files to skip expensive file open call

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2205,8 +2205,7 @@ static std::string _openHeader(std::ifstream &f, const std::string &path)
     f.open(simplePath.c_str());
     if (f.is_open())
         return simplePath;
-    else
-    {
+    else {
         nonExistingFilesCache.add(simplePath);
         return "";
     }
@@ -2243,7 +2242,7 @@ static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const
 
         std::string simplePath = _openHeader(f, s);
         if (!simplePath.empty())
-          return simplePath;
+            return simplePath;
     }
 
     return "";


### PR DESCRIPTION
This PR fixes #151: Caches the file paths of all non-existing header files in a thread-safe set.

As agreed upon in #151, caching is enabled for Windows only.

Time measurements showed that caching the results of simplecpp::simplifyPath does not decrease checking time significantly, so I did not change anything in simplifyPath.
