### PR TITLE
3 fixes for realFileName/realFilename

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1994,9 +1994,12 @@ static std::string realFilename(const std::string &f)
                 continue;
             }
 
+            bool isDriveSpecification = 
+                (pos == 2 && subpath.size() == 2 && std::isalpha(subpath[0]) && subpath[1] == ':');
+
             // Append real filename (proper case)
             std::string f2;
-            if (realFileName(f.substr(0,pos),&f2))
+            if (!isDriveSpecification && realFileName(f.substr(0, pos), &f2))
                 ret += f2;
             else
                 ret += subpath;

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -312,6 +312,9 @@ namespace simplecpp {
 
     /** Simplify path */
     SIMPLECPP_LIB std::string simplifyPath(std::string path);
+
+    /** Convert Cygwin path to Windows path */
+    SIMPLECPP_LIB std::string convertCygwinToWindowsPath(const std::string &cygwinPath);
 }
 
 #endif

--- a/test.cpp
+++ b/test.cpp
@@ -208,6 +208,24 @@ static void constFold()
     ASSERT_EQUALS("exception", testConstFold("?2:3"));
 }
 
+static void convertCygwinPath()
+{
+    // absolute paths
+    ASSERT_EQUALS("X:\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/x"));     // initial backslash
+    ASSERT_EQUALS("X:\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/"));
+    ASSERT_EQUALS("X:\\dir", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/dir"));
+    ASSERT_EQUALS("X:\\dir\\file", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/dir/file"));
+
+    // relative paths
+    ASSERT_EQUALS("file", simplecpp::convertCygwinToWindowsPath("file"));
+    ASSERT_EQUALS("dir\\file", simplecpp::convertCygwinToWindowsPath("dir/file"));
+    ASSERT_EQUALS("..\\dir\\file", simplecpp::convertCygwinToWindowsPath("../dir/file"));
+
+    // incorrect Cygwin paths
+    ASSERT_EQUALS("\\cygdrive", simplecpp::convertCygwinToWindowsPath("/cygdrive"));
+    ASSERT_EQUALS("\\cygdrive\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/"));
+}
+
 static void define1()
 {
     const char code[] = "#define A 1+2\n"
@@ -1598,24 +1616,6 @@ static void simplifyPath_New()
     ASSERT_EQUALS("/", simplecpp::simplifyPath("\\"));
 }
 
-static void convertCygwinPath()
-{
-    // absolute paths
-    ASSERT_EQUALS("X:\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/x"));     // initial backslash
-    ASSERT_EQUALS("X:\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/"));
-    ASSERT_EQUALS("X:\\dir", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/dir"));
-    ASSERT_EQUALS("X:\\dir\\file", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/dir/file"));
-
-    // relative paths
-    ASSERT_EQUALS("file", simplecpp::convertCygwinToWindowsPath("file"));
-    ASSERT_EQUALS("dir\\file", simplecpp::convertCygwinToWindowsPath("dir/file"));
-    ASSERT_EQUALS("..\\dir\\file", simplecpp::convertCygwinToWindowsPath("../dir/file"));
-
-    // incorrect Cygwin paths
-    ASSERT_EQUALS("\\cygdrive", simplecpp::convertCygwinToWindowsPath("/cygdrive"));
-    ASSERT_EQUALS("\\cygdrive\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/"));
-}
-
 static void preprocessSizeOf()
 {
     simplecpp::OutputList outputList;
@@ -1649,6 +1649,8 @@ int main(int argc, char **argv)
     TEST_CASE(comment_multiline);
 
     TEST_CASE(constFold);
+
+    TEST_CASE(convertCygwinPath);
 
     TEST_CASE(define1);
     TEST_CASE(define2);
@@ -1781,8 +1783,6 @@ int main(int argc, char **argv)
     TEST_CASE(simplifyPath);
     TEST_CASE(simplifyPath_cppcheck);
     TEST_CASE(simplifyPath_New);
-
-    TEST_CASE(convertCygwinPath);
 
     TEST_CASE(preprocessSizeOf);
 

--- a/test.cpp
+++ b/test.cpp
@@ -1598,6 +1598,24 @@ static void simplifyPath_New()
     ASSERT_EQUALS("/", simplecpp::simplifyPath("\\"));
 }
 
+static void convertCygwinPath()
+{
+    // absolute paths
+    ASSERT_EQUALS("X:\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/x"));     // initial backslash
+    ASSERT_EQUALS("X:\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/"));
+    ASSERT_EQUALS("X:\\dir", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/dir"));
+    ASSERT_EQUALS("X:\\dir\\file", simplecpp::convertCygwinToWindowsPath("/cygdrive/x/dir/file"));
+
+    // relative paths
+    ASSERT_EQUALS("file", simplecpp::convertCygwinToWindowsPath("file"));
+    ASSERT_EQUALS("dir\\file", simplecpp::convertCygwinToWindowsPath("dir/file"));
+    ASSERT_EQUALS("..\\dir\\file", simplecpp::convertCygwinToWindowsPath("../dir/file"));
+
+    // incorrect Cygwin paths
+    ASSERT_EQUALS("\\cygdrive", simplecpp::convertCygwinToWindowsPath("/cygdrive"));
+    ASSERT_EQUALS("\\cygdrive\\", simplecpp::convertCygwinToWindowsPath("/cygdrive/"));
+}
+
 static void preprocessSizeOf()
 {
     simplecpp::OutputList outputList;
@@ -1763,6 +1781,8 @@ int main(int argc, char **argv)
     TEST_CASE(simplifyPath);
     TEST_CASE(simplifyPath_cppcheck);
     TEST_CASE(simplifyPath_New);
+
+    TEST_CASE(convertCygwinPath);
 
     TEST_CASE(preprocessSizeOf);
 


### PR DESCRIPTION
Here are the fixes for the bugs discussed in #152:
- fix for loop condition in realFileName: scan also f[0]
- use separate caches for realFilename (realFilePathMap stores entire paths) and realFileName (realFileNameMap stores file names)
- convert Cygwin paths to Windows paths in call to FindFirstFileExA
  - added testcase for convertCygwinToWindowsPath

I put convertCygwinToWindowsPath into namespace simplecpp to be able to access it from test.cpp.