### PR TITLE
Fix multiline prefixed string literals in macros

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -555,32 +555,31 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
 
         // string / char literal
         else if (ch == '\"' || ch == '\'') {
+            std::string prefix;
             if (cback() && cback()->name && !std::isspace(prevChar(istr, bom)) && (isStringLiteralPrefix(cback()->str()))) {
+                prefix = cback()->str();
+            }
+            // C++11 raw string literal
+            if (ch == '\"' && !prefix.empty() && *cback()->str().rbegin() == 'R') {
                 std::string delim;
                 currentToken = ch;
-                bool hasR = *cback()->str().rbegin() == 'R';
-                std::string prefix = cback()->str();
-                if (hasR) {
-                    prefix.resize(prefix.size() - 1);
-                    delim = ")";
+                prefix.resize(prefix.size() - 1);
+                ch = readChar(istr,bom);
+                while (istr.good() && ch != '(' && ch != '\n') {
+                    delim += ch;
                     ch = readChar(istr,bom);
-                    while (istr.good() && ch != '(' && ch != '\n') {
-                        delim += ch;
-                        ch = readChar(istr,bom);
-                    }
-                    if (!istr.good() || ch == '\n')
-                        // TODO report
-                        return;
                 }
-                const std::string endOfRawString(delim + currentToken);
+                if (!istr.good() || ch == '\n')
+                    // TODO report
+                    return;
+                const std::string endOfRawString(')' + delim + currentToken);
                 while (istr.good() && !(endsWith(currentToken, endOfRawString) && currentToken.size() > 1))
                     currentToken += readChar(istr,bom);
                 if (!endsWith(currentToken, endOfRawString))
                     // TODO report
                     return;
                 currentToken.erase(currentToken.size() - endOfRawString.size(), endOfRawString.size() - 1U);
-                if (hasR)
-                    currentToken = escapeString(currentToken);
+                currentToken = escapeString(currentToken);
                 currentToken.insert(0, prefix);
                 back()->setstr(currentToken);
                 location.adjust(currentToken);
@@ -588,6 +587,7 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                     location.col += 2 + 2 * delim.size();
                 else
                     location.col += 1 + delim.size();
+
                 continue;
             }
 
@@ -604,7 +604,10 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                 newlines++;
             }
 
-            push_back(new Token(s, location)); // push string without newlines
+            if (prefix.empty())
+                push_back(new Token(s, location)); // push string without newlines
+            else
+                back()->setstr(prefix + s);
 
             if (newlines > 0 && lastLine().compare(0,9,"# define ") == 0) {
                 multiline += newlines;

--- a/test.cpp
+++ b/test.cpp
@@ -1162,6 +1162,22 @@ static void multiline7()   // multiline string in macro
                   "A ( 1 )", rawtokens.stringify());
 }
 
+static void multiline8()   // multiline prefix string in macro
+{
+    const char code[] = "#define A L\"a\\\n"
+                        " b\"\n"
+                        "A;";
+    ASSERT_EQUALS("\n\nL\"a b\" ;", preprocess(code));
+}
+
+static void multiline9()   // multiline prefix string in macro
+{
+    const char code[] = "#define A u8\"a\\\n"
+                        " b\"\n"
+                        "A;";
+    ASSERT_EQUALS("\n\nu8\"a b\" ;", preprocess(code));
+}
+
 static void nullDirective1()
 {
     const char code[] = "#\n"
@@ -1803,6 +1819,8 @@ int main(int argc, char **argv)
     TEST_CASE(multiline5); // column
     TEST_CASE(multiline6); // multiline string in macro
     TEST_CASE(multiline7); // multiline string in macro
+    TEST_CASE(multiline8); // multiline prefix string in macro
+    TEST_CASE(multiline9); // multiline prefix string in macro
 
     TEST_CASE(readfile_nullbyte);
     TEST_CASE(readfile_char);


### PR DESCRIPTION
Commit 4e022f0a8d7c2a669260e1a0f93dc27d4bad702d broke parsing of
multiline prefixed strings in defines. The commit changed so all
prefixed strings went through the same code path that previously
only raw string literals did. That didn't handle newlines in
defines well. Change this to strip out the prefix first, and then
check if it is a raw string or not.