### PR TITLE
Add error message to ill-formed string and character literals

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -569,15 +569,29 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                     delim += ch;
                     ch = readChar(istr,bom);
                 }
-                if (!istr.good() || ch == '\n')
-                    // TODO report
+                if (!istr.good() || ch == '\n') {
+                    if (outputList) {
+                        Output err(files);
+                        err.type = Output::SYNTAX_ERROR;
+                        err.location = location;
+                        err.msg = "Invalid newline in raw string delimiter.";
+                        outputList->push_back(err);
+                    }
                     return;
+                }
                 const std::string endOfRawString(')' + delim + currentToken);
                 while (istr.good() && !(endsWith(currentToken, endOfRawString) && currentToken.size() > 1))
                     currentToken += readChar(istr,bom);
-                if (!endsWith(currentToken, endOfRawString))
-                    // TODO report
+                if (!endsWith(currentToken, endOfRawString)) {
+                    if (outputList) {
+                        Output err(files);
+                        err.type = Output::SYNTAX_ERROR;
+                        err.location = location;
+                        err.msg = "Raw string missing terminating delimiter.";
+                        outputList->push_back(err);
+                    }
                     return;
+                }
                 currentToken.erase(currentToken.size() - endOfRawString.size(), endOfRawString.size() - 1U);
                 currentToken = escapeString(currentToken);
                 currentToken.insert(0, prefix);
@@ -593,7 +607,7 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
 
             currentToken = readUntil(istr,location,ch,ch,outputList,bom);
             if (currentToken.size() < 2U)
-                // TODO report
+                // Error is reported by readUntil()
                 return;
 
             std::string s = currentToken;

--- a/test.cpp
+++ b/test.cpp
@@ -1383,6 +1383,18 @@ static void readfile_char()
     ASSERT_EQUALS("A = u8 'c'", readfile("A = u8 'c'"));
 }
 
+static void readfile_char_error()
+{
+    simplecpp::OutputList outputList;
+
+    readfile("A = L's", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,No pair for character (\'). Can't process file. File is either invalid or unicode, which is currently not supported.\n", toString(outputList));
+    outputList.clear();
+
+    readfile("A = 's\n'", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,No pair for character (\'). Can't process file. File is either invalid or unicode, which is currently not supported.\n", toString(outputList));
+}
+
 static void readfile_string()
 {
     ASSERT_EQUALS("\"\"", readfile("\"\""));
@@ -1411,6 +1423,43 @@ static void readfile_string()
     ASSERT_EQUALS("A = u\"abc\"", readfile("A = uR\"(abc)\""));
     ASSERT_EQUALS("A = U\"abc\"", readfile("A = UR\"(abc)\""));
     ASSERT_EQUALS("A = u8\"abc\"", readfile("A = u8R\"(abc)\""));
+}
+
+static void readfile_string_error()
+{
+    simplecpp::OutputList outputList;
+
+    readfile("A = \"abs", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,No pair for character (\"). Can't process file. File is either invalid or unicode, which is currently not supported.\n", toString(outputList));
+    outputList.clear();
+
+    readfile("A = u8\"abs\n\"", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,No pair for character (\"). Can't process file. File is either invalid or unicode, which is currently not supported.\n", toString(outputList));
+    outputList.clear();
+
+    readfile("A = R\"as\n(abc)as\"", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,Invalid newline in raw string delimiter.\n", toString(outputList));
+    outputList.clear();
+
+    readfile("A = u8R\"as\n(abc)as\"", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,Invalid newline in raw string delimiter.\n", toString(outputList));
+    outputList.clear();
+
+    readfile("A = R\"as(abc)a\"", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,Raw string missing terminating delimiter.\n", toString(outputList));
+    outputList.clear();
+
+    readfile("A = LR\"as(abc)a\"", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,Raw string missing terminating delimiter.\n", toString(outputList));
+    outputList.clear();
+
+    readfile("#define A \"abs", -1, &outputList);
+    ASSERT_EQUALS("file0,1,syntax_error,No pair for character (\"). Can't process file. File is either invalid or unicode, which is currently not supported.\n", toString(outputList));
+    outputList.clear();
+
+    // Don't warn for a multiline define
+    readfile("#define A \"abs\\\n\"", -1, &outputList);
+    ASSERT_EQUALS("", toString(outputList));
 }
 
 static void readfile_cpp14_number()
@@ -1824,7 +1873,9 @@ int main(int argc, char **argv)
 
     TEST_CASE(readfile_nullbyte);
     TEST_CASE(readfile_char);
+    TEST_CASE(readfile_char_error);
     TEST_CASE(readfile_string);
+    TEST_CASE(readfile_string_error);
     TEST_CASE(readfile_cpp14_number);
     TEST_CASE(readfile_unhandled_chars);
     TEST_CASE(readfile_error);


### PR DESCRIPTION
Add error messages to ill formed raw string literals. There was a TODO
for adding an error message in case reading a string failed, (i.e., it
was not terminated properly. There was already an error message from
readUntil() so remove the TODO and add a few test cases.