### PR TITLE
Fix check if previous read character was space

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -327,15 +327,6 @@ static void ungetChar(std::istream &istr, unsigned int bom)
         istr.unget();
 }
 
-static unsigned char prevChar(std::istream &istr, unsigned int bom)
-{
-    ungetChar(istr, bom);
-    ungetChar(istr, bom);
-    unsigned char c = readChar(istr, bom);
-    readChar(istr, bom);
-    return c;
-}
-
 static unsigned short getAndSkipBOM(std::istream &istr)
 {
     const int ch1 = istr.peek();
@@ -556,7 +547,8 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
         // string / char literal
         else if (ch == '\"' || ch == '\'') {
             std::string prefix;
-            if (cback() && cback()->name && !std::isspace(prevChar(istr, bom)) && (isStringLiteralPrefix(cback()->str()))) {
+            if (cback() && cback()->name && isStringLiteralPrefix(cback()->str()) &&
+                ((cback()->location.col + cback()->str().size()) == location.col)) {
                 prefix = cback()->str();
             }
             // C++11 raw string literal

--- a/test.cpp
+++ b/test.cpp
@@ -309,6 +309,13 @@ static void define9()
     ASSERT_EQUALS("\nab . AB . CD", preprocess(code));
 }
 
+static void define10()   // don't combine prefix with space in macro
+{
+    const char code[] = "#define A u8 \"a b\"\n"
+                        "A;";
+    ASSERT_EQUALS("\nu8 \"a b\" ;", preprocess(code));
+}
+
 static void define_invalid_1()
 {
     std::istringstream istr("#define  A(\nB\n");
@@ -1792,6 +1799,7 @@ int main(int argc, char **argv)
     TEST_CASE(define7);
     TEST_CASE(define8);
     TEST_CASE(define9);
+    TEST_CASE(define10);
     TEST_CASE(define_invalid_1);
     TEST_CASE(define_invalid_2);
     TEST_CASE(define_define_1);


### PR DESCRIPTION
The prevChar was broken in the sense that there is no guarantee that
unget can be called more than once on a stream. This lead to problems in
some cases on some operative systems. Fix this by saving the state
before reading the character. Note that prevIsSpace is not valid in the
entire while loop, if characters are read on other places than at the
start of the while loop, the value will be wrong. This is the case in
the only place that it is being used.

This feels like a very brittle solution...