### PR TITLE
added move constructor and assignment for TokenList

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -200,6 +200,13 @@ simplecpp::TokenList::TokenList(const TokenList &other) : frontToken(NULL), back
     *this = other;
 }
 
+#if __cplusplus >= 201103L
+simplecpp::TokenList::TokenList(TokenList &&other) : frontToken(NULL), backToken(NULL), files(other.files)
+{
+    *this = std::move(other);
+}
+#endif
+
 simplecpp::TokenList::~TokenList()
 {
     clear();
@@ -215,6 +222,21 @@ simplecpp::TokenList &simplecpp::TokenList::operator=(const TokenList &other)
     }
     return *this;
 }
+
+#if __cplusplus >= 201103L
+simplecpp::TokenList &simplecpp::TokenList::operator=(TokenList &&other)
+{
+    if (this != &other) {
+        clear();
+        backToken = other.backToken;
+        other.backToken = NULL;
+        frontToken = other.frontToken;
+        other.frontToken = NULL;
+        sizeOfType = std::move(other.sizeOfType);
+    }
+    return *this;
+}
+#endif
 
 void simplecpp::TokenList::clear()
 {

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -181,8 +181,14 @@ namespace simplecpp {
         explicit TokenList(std::vector<std::string> &filenames);
         TokenList(std::istream &istr, std::vector<std::string> &filenames, const std::string &filename=std::string(), OutputList *outputList = 0);
         TokenList(const TokenList &other);
+#if __cplusplus >= 201103L
+        TokenList(TokenList &&other);
+#endif
         ~TokenList();
         TokenList &operator=(const TokenList &other);
+#if __cplusplus >= 201103L
+        TokenList &operator=(TokenList &&other);
+#endif
 
         void clear();
         bool empty() const {


### PR DESCRIPTION
gets rid of copy of result in Preprocessor::preprocess()

reduces Ir from 14.98% to 12.70% with package pion according to callgrind