### PR TITLE
 updated CMake to include warnings and syntax check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required (VERSION 3.5)
 project (simplecpp LANGUAGES CXX)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     add_compile_options(-Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wshadow -Wundef)
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Weverything)
     # no need for c++98 compatibility
     add_compile_options(-Wno-c++98-compat-pedantic)
@@ -18,14 +18,18 @@ endif()
 add_executable(simplecpp simplecpp.cpp main.cpp)
 set_property(TARGET simplecpp PROPERTY CXX_STANDARD 11)
 
-add_library(simplecpp-03-syntax STATIC simplecpp.cpp)
-target_compile_options(simplecpp-03-syntax PRIVATE -std=c++03)
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(simplecpp-03-syntax PRIVATE -Wno-long-long)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(simplecpp-03-syntax PRIVATE -Wno-c++11-long-long)
+# it is not possible to set a standard older than C++14 with Visual Studio
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # we need to create a dummy library as -fsyntax-only will not produce any output files causing the build to fail
+    add_library(simplecpp-03-syntax STATIC simplecpp.cpp)
+    target_compile_options(simplecpp-03-syntax PRIVATE -std=c++03)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        target_compile_options(simplecpp-03-syntax PRIVATE -Wno-long-long)
+    elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(simplecpp-03-syntax PRIVATE -Wno-c++11-long-long)
+    endif()
+    add_dependencies(simplecpp simplecpp-03-syntax)
 endif()
-add_dependencies(simplecpp simplecpp-03-syntax)
 
 add_executable(testrunner simplecpp.cpp test.cpp)
 set_property(TARGET testrunner PROPERTY CXX_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,31 @@
 cmake_minimum_required (VERSION 3.5)
-project (simplecpp)
+project (simplecpp LANGUAGES CXX)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options(-Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wshadow -Wundef)
+endif()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    add_compile_options(-Weverything)
+    # no need for c++98 compatibility
+    add_compile_options(-Wno-c++98-compat-pedantic)
+    # these are not really fixable
+    add_compile_options(-Wno-exit-time-destructors -Wno-global-constructors)
+    # TODO: fix these?
+    add_compile_options(-Wno-zero-as-null-pointer-constant -Wno-padded -Wno-sign-conversion -Wno-conversion -Wno-old-style-cast)
+endif()
 
 add_executable(simplecpp simplecpp.cpp main.cpp)
 set_property(TARGET simplecpp PROPERTY CXX_STANDARD 11)
+
+add_library(simplecpp-03-syntax STATIC simplecpp.cpp)
+target_compile_options(simplecpp-03-syntax PRIVATE -std=c++03)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_compile_options(simplecpp-03-syntax PRIVATE -Wno-long-long)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(simplecpp-03-syntax PRIVATE -Wno-c++11-long-long)
+endif()
+add_dependencies(simplecpp simplecpp-03-syntax)
 
 add_executable(testrunner simplecpp.cpp test.cpp)
 set_property(TARGET testrunner PROPERTY CXX_STANDARD 11)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:	testrunner simplecpp
 
-CXXFLAGS = -Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wshadow -Wundef -g
+CXXFLAGS = -Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wshadow -Wundef -std=c++0x -g
 LDFLAGS = -g
 
 %.o: %.cpp	simplecpp.h

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:	testrunner simplecpp
 
-CXXFLAGS = -Wall -Wextra  -Wabi -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wshadow -pedantic -g -std=c++0x
+CXXFLAGS = -Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wshadow -Wundef -g
 LDFLAGS = -g
 
 %.o: %.cpp	simplecpp.h

--- a/test.cpp
+++ b/test.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "simplecpp.h"
 
-int numberOfFailedAssertions = 0;
+static int numberOfFailedAssertions = 0;
 
 #define ASSERT_EQUALS(expected, actual)  (assertEquals((expected), (actual), __LINE__))
 


### PR DESCRIPTION
also removed -Wabi since it will no longer warn by itself will report the following for each file:
```
cc1plus: warning: -Wabi won't warn about anything [-Wabi]
cc1plus: note: -Wabi warns about differences from the most up-to-date ABI, which is also used by default
cc1plus: note: use e.g. -Wabi=11 to warn about changes from GCC 7
```

add -Wundef since it is a useful warning