### PR TITLE
Added octal numbers recognition

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -45,6 +45,11 @@ static bool isHex(const std::string &s)
     return s.size()>2 && (s.compare(0,2,"0x")==0 || s.compare(0,2,"0X")==0);
 }
 
+static bool isOct(const std::string &s)
+{
+    return s.size()>1 && (s.compare(0,1,"0")==0);
+}
+
 
 static const simplecpp::TokenString DEFINE("define");
 static const simplecpp::TokenString UNDEF("undef");
@@ -76,9 +81,12 @@ static long long stringToLL(const std::string &s)
 {
     long long ret;
     const bool hex = isHex(s);
-    std::istringstream istr(hex ? s.substr(2) : s);
+    const bool oct = isOct(s);
+    std::istringstream istr(hex ? s.substr(2) : oct ? s.substr(1) : s);
     if (hex)
         istr >> std::hex;
+    else if (oct)
+        istr >> std::oct;
     istr >> ret;
     return ret;
 }
@@ -87,9 +95,12 @@ static unsigned long long stringToULL(const std::string &s)
 {
     unsigned long long ret;
     const bool hex = isHex(s);
-    std::istringstream istr(hex ? s.substr(2) : s);
+    const bool oct = isOct(s);
+    std::istringstream istr(hex ? s.substr(2) : oct ? s.substr(1) : s);
     if (hex)
         istr >> std::hex;
+    else if (oct)
+        istr >> std::oct;
     istr >> ret;
     return ret;
 }
@@ -765,7 +776,7 @@ void simplecpp::TokenList::combineOperators()
         }
         // match: [0-9.]+E [+-] [0-9]+
         const char lastChar = tok->str()[tok->str().size() - 1];
-        if (tok->number && !isHex(tok->str()) && (lastChar == 'E' || lastChar == 'e') && tok->next && tok->next->isOneOf("+-") && tok->next->next && tok->next->next->number) {
+        if (tok->number && !isHex(tok->str()) && !isOct(tok->str()) && (lastChar == 'E' || lastChar == 'e') && tok->next && tok->next->isOneOf("+-") && tok->next->next && tok->next->next->number) {
             tok->setstr(tok->str() + tok->next->op + tok->next->next->str());
             deleteToken(tok->next);
             deleteToken(tok->next);

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -47,7 +47,7 @@ static bool isHex(const std::string &s)
 
 static bool isOct(const std::string &s)
 {
-    return s.size()>1 && (s.compare(0,1,"0")==0);
+    return s.size()>1 && (s[0]=='0') && (s[1] >= '0') && (s[1] < '8');
 }
 
 

--- a/test.cpp
+++ b/test.cpp
@@ -204,6 +204,8 @@ static void constFold()
     ASSERT_EQUALS("29", testConstFold("13 ^ 16"));
     ASSERT_EQUALS("25", testConstFold("24 | 1"));
     ASSERT_EQUALS("2", testConstFold("1?2:3"));
+    ASSERT_EQUALS("24", testConstFold("010+020"));
+    ASSERT_EQUALS("1", testConstFold("010==8"));
     ASSERT_EQUALS("exception", testConstFold("!1 ? 2 :"));
     ASSERT_EQUALS("exception", testConstFold("?2:3"));
 }


### PR DESCRIPTION
Working with cppcheck I've faced off the issue in case using macros with octal numbers (access modes for files in UNIX). So I've create patch for simplecpp.cpp to fix this issue. The patch has been tested for a while in my own cppcheck build. I guess that it looks stable to be included in master.
