### PR TITLE
make ellipsis ... a single token

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -756,10 +756,14 @@ void simplecpp::TokenList::combineOperators()
         }
 
         if (tok->op == '.') {
-            if (tok->previous && tok->previous->op == '.')
+            // ellipsis ...
+            if (tok->next && tok->next->op == '.' && tok->next->location.col == (tok->location.col + 1) &&
+                tok->next->next && tok->next->next->op == '.' && tok->next->next->location.col == (tok->location.col + 2)) {
+                tok->setstr("...");
+                deleteToken(tok->next);
+                deleteToken(tok->next);
                 continue;
-            if (tok->next && tok->next->op == '.')
-                continue;
+            }
             // float literals..
             if (tok->previous && tok->previous->number) {
                 tok->setstr(tok->previous->str() + '.');
@@ -1387,14 +1391,12 @@ namespace simplecpp {
                 args.clear();
                 const Token *argtok = nameTokDef->next->next;
                 while (sameline(nametoken, argtok) && argtok->op != ')') {
-                    if (argtok->op == '.' &&
-                        argtok->next && argtok->next->op == '.' &&
-                        argtok->next->next && argtok->next->next->op == '.' &&
-                        argtok->next->next->next && argtok->next->next->next->op == ')') {
+                    if (argtok->str() == "..." &&
+                        argtok->next && argtok->next->op == ')') {
                         variadic = true;
                         if (!argtok->previous->name)
                             args.push_back("__VA_ARGS__");
-                        argtok = argtok->next->next->next; // goto ')'
+                        argtok = argtok->next; // goto ')'
                         break;
                     }
                     if (argtok->op != ',')

--- a/test.cpp
+++ b/test.cpp
@@ -175,6 +175,12 @@ static void combineOperators_andequal()
     ASSERT_EQUALS("f ( x &= 2 ) ;", preprocess("f(x &= 2);"));
 }
 
+static void combineOperators_ellipsis()
+{
+    ASSERT_EQUALS("void f ( int , ... ) ;", preprocess("void f(int, ...);"));
+    ASSERT_EQUALS("void f ( ) { switch ( x ) { case 1 ... 4 : } }", preprocess("void f() { switch(x) { case 1 ... 4: } }"));
+}
+
 static void comment()
 {
     ASSERT_EQUALS("// abc", readfile("// abc"));
@@ -504,11 +510,6 @@ static void dollar()
 {
     ASSERT_EQUALS("$ab", readfile("$ab"));
     ASSERT_EQUALS("a$b", readfile("a$b"));
-}
-
-static void dotDotDot()
-{
-    ASSERT_EQUALS("1 . . . 2", readfile("1 ... 2"));
 }
 
 static void error1()
@@ -1829,6 +1830,7 @@ int main(int argc, char **argv)
     TEST_CASE(combineOperators_increment);
     TEST_CASE(combineOperators_coloncolon);
     TEST_CASE(combineOperators_andequal);
+    TEST_CASE(combineOperators_ellipsis);
 
     TEST_CASE(comment);
     TEST_CASE(comment_multiline);
@@ -1871,8 +1873,6 @@ int main(int argc, char **argv)
     TEST_CASE(define_ifdef);
 
     TEST_CASE(dollar);
-
-    TEST_CASE(dotDotDot); // ...
 
     TEST_CASE(error1);
     TEST_CASE(error2);


### PR DESCRIPTION
Using cppcheck -E to preprocess code with ellipsis produces output that
can't be compiled because ... is split into 3 tokens.