### PR TITLE
Fix #120 (handle multiline character literals)

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1133,12 +1133,20 @@ std::string simplecpp::TokenList::readUntil(std::istream &istr, const Location &
         backslash = false;
         ret += ch;
         if (ch == '\\') {
-            const char next = readChar(istr, bom);
-            if (next == '\r' || next == '\n') {
-                ret.erase(ret.size()-1U);
-                backslash = (next == '\r');
-            }
-            ret += next;
+            bool update_ch = false;
+            char next = 0;
+            do {
+                next = readChar(istr, bom);
+                if (next == '\r' || next == '\n') {
+                    ret.erase(ret.size()-1U);
+                    backslash = (next == '\r');
+                    update_ch = false;
+                } else if (next == '\\')
+                    update_ch = !update_ch;
+                ret += next;
+            } while (next == '\\');
+            if (update_ch)
+                ch = next;
         }
     }
 

--- a/test.cpp
+++ b/test.cpp
@@ -1229,6 +1229,13 @@ static void multiline9()   // multiline prefix string in macro
     ASSERT_EQUALS("\n\nu8\"a b\" ;", preprocess(code));
 }
 
+static void multiline10() // multiline string literal
+{
+    const char code[] = "const char *ptr = \"\\\\\n"
+                        "\\n\";";
+    ASSERT_EQUALS("const char * ptr = \"\\\\n\"\n;", preprocess(code));
+}
+
 static void nullDirective1()
 {
     const char code[] = "#\n"
@@ -1947,6 +1954,7 @@ int main(int argc, char **argv)
     TEST_CASE(multiline7); // multiline string in macro
     TEST_CASE(multiline8); // multiline prefix string in macro
     TEST_CASE(multiline9); // multiline prefix string in macro
+    TEST_CASE(multiline10);
 
     TEST_CASE(readfile_nullbyte);
     TEST_CASE(readfile_char);


### PR DESCRIPTION
Make simplecpp accept the following code:

	const char*ptr="\\
	\n";

Output from simplecpp:

	const char * ptr = "\\n"
	;

Output from gcc -E:

	const char* ptr = "\\n";

Do this by extending the special casing for backslashes to read all
consecutive backslashes before continuing.

This makes it possible to run simplecpp on ftp://ftp.se.debian.org/debian/pool/main/l/lisaac/lisaac_0.39~rc1.orig.tar.gz
(used in cppcheck daca@home). Processing it is a blocker for cppcheck trac ticket [#2435](https://trac.cppcheck.net/ticket/2435).

Fixes #120.