### PR TITLE
Improve support for hexadecimal floating point literal

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -780,7 +780,10 @@ void simplecpp::TokenList::combineOperators()
         }
         // match: [0-9.]+E [+-] [0-9]+
         const char lastChar = tok->str()[tok->str().size() - 1];
-        if (tok->number && !isHex(tok->str()) && !isOct(tok->str()) && (lastChar == 'E' || lastChar == 'e') && tok->next && tok->next->isOneOf("+-") && tok->next->next && tok->next->next->number) {
+        if (tok->number && !isOct(tok->str()) &&
+            ((!isHex(tok->str()) && (lastChar == 'E' || lastChar == 'e')) ||
+             (isHex(tok->str()) && (lastChar == 'P' || lastChar == 'p'))) &&
+            tok->next && tok->next->isOneOf("+-") && tok->next->next && tok->next->next->number) {
             tok->setstr(tok->str() + tok->next->op + tok->next->next->str());
             deleteToken(tok->next);
             deleteToken(tok->next);

--- a/test.cpp
+++ b/test.cpp
@@ -154,6 +154,11 @@ static void combineOperators_floatliteral()
     ASSERT_EQUALS("1E-7", preprocess("1E-7"));
     ASSERT_EQUALS("1E+7", preprocess("1E+7"));
     ASSERT_EQUALS("0x1E + 7", preprocess("0x1E+7"));
+    ASSERT_EQUALS("0x1.2p3", preprocess("0x1.2p3"));
+    ASSERT_EQUALS("0x1p+3", preprocess("0x1p+3"));
+    ASSERT_EQUALS("0x1p+3f", preprocess("0x1p+3f"));
+    ASSERT_EQUALS("0x1p+3L", preprocess("0x1p+3L"));
+    ASSERT_EQUALS("1p + 3", preprocess("1p+3"));
 }
 
 static void combineOperators_increment()


### PR DESCRIPTION
Handle plus and minus sign in the exponent. Hexadecimal floating point
numbers were added in C99 and C++17.

References:
https://en.cppreference.com/w/cpp/language/floating_literal
https://en.cppreference.com/w/c/language/floating_constant

I think this should be sufficient to close cppcheck trac ticket [#6514](https://trac.cppcheck.net/ticket/6514).
Related is [#8886](https://trac.cppcheck.net/ticket/8886), but that seems to be a design decision to warn about equality for floating point values.