### PR TITLE
simplecpp.cpp: Issue error when an explicitly included file is not found

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -86,6 +86,9 @@ int main(int argc, char **argv)
         case simplecpp::Output::UNHANDLED_CHAR_ERROR:
             std::cerr << "unhandled char error: ";
             break;
+        case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
+            std::cerr << "explicit include not found: ";
+            break;
         }
         std::cerr << output.msg << std::endl;
     }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2429,7 +2429,7 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
         if (!fin.is_open()) {
             if (outputList) {
                 simplecpp::Output err(fileNumbers);
-                err.type = simplecpp::Output::ERROR;
+                err.type = simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND;
                 err.location = Location(fileNumbers);
                 err.msg = "Can not open include file '" + filename + "' that is explicitly included.";
                 outputList->push_back(err);

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2431,7 +2431,7 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
                 simplecpp::Output err(fileNumbers);
                 err.type = simplecpp::Output::ERROR;
                 err.location = Location(fileNumbers);
-                err.msg = "Can not open include file '" + filename + "' that is explicitly included for all files.";
+                err.msg = "Can not open include file '" + filename + "' that is explicitly included.";
                 outputList->push_back(err);
             }
             continue;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2426,8 +2426,16 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
             continue;
 
         std::ifstream fin(filename.c_str());
-        if (!fin.is_open())
+        if (!fin.is_open()) {
+            if (outputList) {
+                simplecpp::Output err(fileNumbers);
+                err.type = simplecpp::Output::MISSING_HEADER;
+                err.location = Location(fileNumbers);
+                err.msg = "Can not open include file '" + filename + "' that is explicitly included for all files.";
+                outputList->push_back(err);
+            }
             continue;
+        }
 
         TokenList *tokenlist = new TokenList(fin, fileNumbers, filename, outputList);
         if (!tokenlist->front()) {

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2429,7 +2429,7 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
         if (!fin.is_open()) {
             if (outputList) {
                 simplecpp::Output err(fileNumbers);
-                err.type = simplecpp::Output::MISSING_HEADER;
+                err.type = simplecpp::Output::ERROR;
                 err.location = Location(fileNumbers);
                 err.msg = "Can not open include file '" + filename + "' that is explicitly included for all files.";
                 outputList->push_back(err);

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -167,7 +167,8 @@ namespace simplecpp {
             INCLUDE_NESTED_TOO_DEEPLY,
             SYNTAX_ERROR,
             PORTABILITY_BACKSLASH,
-            UNHANDLED_CHAR_ERROR
+            UNHANDLED_CHAR_ERROR,
+            EXPLICIT_INCLUDE_NOT_FOUND
         } type;
         Location location;
         std::string msg;

--- a/test.cpp
+++ b/test.cpp
@@ -92,6 +92,9 @@ static std::string toString(const simplecpp::OutputList &outputList)
             break;
         case simplecpp::Output::Type::UNHANDLED_CHAR_ERROR:
             ostr << "unhandled_char_error,";
+            break;
+        case simplecpp::Output::Type::EXPLICIT_INCLUDE_NOT_FOUND:
+            ostr << "explicit_include_not_found,";
         }
 
         ostr << output.msg << '\n';


### PR DESCRIPTION
If a file is explicitly included for example via command line option
`-include=` but can not be opened this error message is issued now.
Example:
$ ./simplecpp -include=blah.h foo.c
int main ( )
{
return 0 ;
}
foo.c:1: missing header: Can not open include file 'blah.h' that is explicitly included for all files.

Fixes #183