### PR TITLE
bug fix - de-escape double backslashes in file paths of #line directives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,3 +33,6 @@ endif()
 
 add_executable(testrunner simplecpp.cpp test.cpp)
 set_property(TARGET testrunner PROPERTY CXX_STANDARD 11)
+
+enable_testing()
+add_test(NAME testrunner COMMAND testrunner)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -137,6 +137,12 @@ static bool isAlternativeUnaryOp(const simplecpp::Token *tok, const std::string 
             (tok->next && (tok->next->name || tok->next->number)));
 }
 
+static std::string replaceAll(std::string s, const std::string& from, const std::string& to)
+{
+  for (size_t pos = s.find(from); pos != std::string::npos; pos = s.find(from, pos + to.size()))
+    s.replace(pos, from.size(), to);
+  return s;
+}
 
 const std::string simplecpp::Location::emptyFileName;
 
@@ -498,7 +504,7 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                 } else if (lastline == "# line %num%") {
                     lineDirective(location.fileIndex, std::atol(cback()->str().c_str()), &location);
                 } else if (lastline == "# %num% %str%" || lastline == "# line %num% %str%") {
-                    lineDirective(fileIndex(cback()->str().substr(1U, cback()->str().size() - 2U)),
+                    lineDirective(fileIndex(replaceAll(cback()->str().substr(1U, cback()->str().size() - 2U),"\\\\","\\")),
                                   std::atol(cback()->previous->str().c_str()), &location);
                 }
                 // #endfile

--- a/test.cpp
+++ b/test.cpp
@@ -1069,6 +1069,14 @@ static void location3()
     ASSERT_EQUALS("\n#line 1 \"x\"\na b", preprocess(code));
 }
 
+static void location4()
+{
+    const char *code;
+    code = "#line 1 \"abc\\\\def.g\" \n"
+           "a\n";
+    ASSERT_EQUALS("\n#line 1 \"abc\\def.g\"\na", preprocess(code));
+}
+
 static void missingHeader1()
 {
     const simplecpp::DUI dui;
@@ -1941,6 +1949,7 @@ int main(int argc, char **argv)
     TEST_CASE(location1);
     TEST_CASE(location2);
     TEST_CASE(location3);
+    TEST_CASE(location4);
 
     TEST_CASE(missingHeader1);
     TEST_CASE(missingHeader2);


### PR DESCRIPTION
As an add-on the test running `testrunner` is added to the cmake test suite.  Please note that there is some more work to be done to `run-tests.py`, since for me this produces an error:

~~~python
$ python3 run-tests.py
Traceback (most recent call last):
  File "run-tests.py", line 18, in <module>
    for line in open(f, 'rt'):
  File "C:/msys64/mingw64/lib/python3.8/encodings/cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 495: character maps to <undefined>
~~~   

@danmar Would you propagate the changes to `simplecpp.cpp` in the `cppcheck` repo?  I am not sure how you keep the files in sync if this is a goal.  But happy to submit the change to `simplecpp.cpp` in a `cppcheck` PR once you are fine with this one.

Thanks. 