### PR TITLE
simplecpp.cpp: astyling

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -139,9 +139,9 @@ static bool isAlternativeUnaryOp(const simplecpp::Token *tok, const std::string 
 
 static std::string replaceAll(std::string s, const std::string& from, const std::string& to)
 {
-  for (size_t pos = s.find(from); pos != std::string::npos; pos = s.find(from, pos + to.size()))
-    s.replace(pos, from.size(), to);
-  return s;
+    for (size_t pos = s.find(from); pos != std::string::npos; pos = s.find(from, pos + to.size()))
+        s.replace(pos, from.size(), to);
+    return s;
 }
 
 const std::string simplecpp::Location::emptyFileName;


### PR DESCRIPTION
@danmar I just realized that for cppcheck files astyle configs are applied. Great I think if this patch is squashed onto fc32948 or applied separately - as you prefer, of course.

Thanks.  