### PR TITLE
run-tests: Make it run with both python 2 and 3

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -5,7 +5,7 @@ import subprocess
 
 def cleanup(out):
   ret = ''
-  for s in out.split('\n'):
+  for s in out.decode('utf-8').split('\n'):
     if len(s) > 1 and s[0] == '#':
       continue
     s = "".join(s.split())


### PR DESCRIPTION
`python` is sometimes python 2 and sometimes python 3. Let's make the tests easy to run regardless.