### PR TITLE
check rfind() result in simplifyPath() before using it - fixes "unsig…

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2223,14 +2223,19 @@ namespace simplecpp {
                 continue;
             }
             // get previous subpath
-            const std::string::size_type pos1 = path.rfind('/', pos - 1U) + 1U;
-            const std::string previousSubPath = path.substr(pos1, pos-pos1);
+            std::string::size_type pos1 = path.rfind('/', pos - 1U);
+            if (pos1 == std::string::npos) {
+                pos1 = 0;
+            } else {
+                pos1 += 1U;
+            }
+            const std::string previousSubPath = path.substr(pos1, pos - pos1);
             if (previousSubPath == "..") {
                 // don't simplify
                 ++pos;
             } else {
                 // remove previous subpath and ".."
-                path.erase(pos1,pos-pos1+4);
+                path.erase(pos1, pos - pos1 + 4);
                 if (path.empty())
                     path = ".";
                 // update pos


### PR DESCRIPTION
…ned integer overflow" reported by UBSAN

```
/mnt/s/GitHub/cppcheck-fw/externals/simplecpp/simplecpp.cpp:2190:75: runtime error: unsigned integer overflow: 18446744073709551615 + 1 cannot be represented in type 'unsigned long'
    #0 0x2e9f4fe in simplecpp::simplifyPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /mnt/s/GitHub/cppcheck-fw/externals/simplecpp/simplecpp.cpp:2190:75
    #1 0x26cc621 in Path::simplifyPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /mnt/s/GitHub/cppcheck-fw/lib/path.cpp:77:12
    #2 0x277eace in Suppressions::ErrorMessage::setFileName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /mnt/s/GitHub/cppcheck-fw/lib/suppressions.cpp:268:17
    #3 0x15a8b1f in TestSuppressions::errorMessage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) const /mnt/s/GitHub/cppcheck-fw/test/testsuppressions.cpp:92:13
    #4 0x1592e8c in TestSuppressions::suppressionsFileNameWithExtraPath() const /mnt/s/GitHub/cppcheck-fw/test/testsuppressions.cpp:153:9
    #5 0x158852a in TestSuppressions::run() /mnt/s/GitHub/cppcheck-fw/test/testsuppressions.cpp:45:9
    #6 0x157ec40 in TestFixture::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /mnt/s/GitHub/cppcheck-fw/test/testsuite.cpp:369:9
    #7 0x157fd62 in TestFixture::runTests(options const&) /mnt/s/GitHub/cppcheck-fw/test/testsuite.cpp:392:23
    #8 0x12f9b85 in main /mnt/s/GitHub/cppcheck-fw/test/testrunner.cpp:44:46
    #9 0x7f3c13dd7cc9 in __libc_start_main csu/../csu/libc-start.c:308:16
    #10 0x8dd649 in _start (/mnt/s/GitHub/cppcheck-fw/cmake-build-debug-wsl-kali-clang-asan-ubsan/bin/testrunner+0x8dd649)
```