### PR TITLE
Fix preprocessing of several ##

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1880,7 +1880,6 @@ namespace simplecpp {
             }
 
             const Token *nextTok = B->next;
-
             if (varargs && tokensB.empty() && tok->previous->str() == ",")
                 output->deleteToken(A);
             else if (strAB != "," && macros.find(strAB) == macros.end()) {
@@ -1888,6 +1887,12 @@ namespace simplecpp {
                 for (Token *b = tokensB.front(); b; b = b->next)
                     b->location = loc;
                 output->takeTokens(tokensB);
+            } else if (nextTok->op == '#' && nextTok->next->op == '#') {
+                TokenList output2(files);
+                output2.push_back(new Token(strAB, tok->location));
+                nextTok = expandHashHash(&output2, loc, nextTok, macros, expandedmacros, parametertokens);
+                output->deleteToken(A);
+                output->takeTokens(output2);
             } else {
                 output->deleteToken(A);
                 TokenList tokens(files);

--- a/test.cpp
+++ b/test.cpp
@@ -804,6 +804,43 @@ static void hashhash11()
     ASSERT_EQUALS("# # #", preprocess(code));
 }
 
+static void hashhash12()
+{
+    {
+        const char code[] = "#define MAX_FOO 1\n"
+                            "#define MAX_FOO_AA 2\n"
+                            "\n"
+                            "#define M(UpperCaseName, b)                "
+                            "  do {                                     "
+                            "    int MaxValue = MAX_##UpperCaseName;    "
+                            "    if (b) {                               "
+                            "      MaxValue = MAX_##UpperCaseName##_AA; "
+                            "    }                                      "
+                            "  } while (0)"
+                            "\n"
+                            "static void f(bool b) { M(FOO, b); }\n";
+
+        ASSERT_EQUALS("\n\n\n\nstatic void f ( bool b ) { do { int MaxValue = 1 ; if ( b ) { MaxValue = 2 ; } } while ( 0 ) ; }", preprocess(code));
+    }
+
+    {
+        const char code[] = "#define MAX_FOO (1 * 1)\n"
+                            "#define MAX_FOO_AA (2 * 1)\n"
+                            "\n"
+                            "#define M(UpperCaseName, b)                "
+                            "  do {                                     "
+                            "    int MaxValue = MAX_##UpperCaseName;    "
+                            "    if (b) {                               "
+                            "      MaxValue = MAX_##UpperCaseName##_AA; "
+                            "    }                                      "
+                            "  } while (0)"
+                            "\n"
+                            "static void f(bool b) { M(FOO, b); }\n";
+
+        ASSERT_EQUALS("\n\n\n\nstatic void f ( bool b ) { do { int MaxValue = ( 1 * 1 ) ; if ( b ) { MaxValue = ( 2 * 1 ) ; } } while ( 0 ) ; }", preprocess(code));
+    }
+}
+
 static void hashhash_invalid_1()
 {
     std::istringstream istr("#define  f(a)  (##x)\nf(1)");
@@ -1973,6 +2010,7 @@ int main(int argc, char **argv)
     TEST_CASE(hashhash9);
     TEST_CASE(hashhash10); // #108 : #define x # #
     TEST_CASE(hashhash11); // #60: #define x # # #
+    TEST_CASE(hashhash12);
     TEST_CASE(hashhash_invalid_1);
     TEST_CASE(hashhash_invalid_2);
 


### PR DESCRIPTION
```
#define MAX_FOO (2 * 1)
#define MAX_FOO_AA (3 * 1)

#define M(UpperCaseName, b)                \
  do {                                     \
    int MaxValue = MAX_##UpperCaseName;    \
    if (b) {                               \
      MaxValue = MAX_##UpperCaseName##_AA; \
    }                                      \
  } while (0)

static void f(bool b) { M(FOO, b); }
```

was a preprocessor error
`a.cpp:4:0: error: failed to expand 'M', Invalid ## usage when expanding 'M'. [preprocessorErrorDirective]`
because `MAX_##UpperCaseName##_AA` was expanded to (2 * 1)##_AA, while gcc or clang happily expand it to `(3 * 1)`.

I don't really know how to add a test here (I've quickly tested with cppcheck and it seemed ok). I see there are some tests in cppcheck/test/testpreprocessor.cpp but I'm probably a bit confused. Any help is more than welcome here ;-)