### PR TITLE
Partial fix for character values with escape sequences (#214)

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -87,7 +87,8 @@ static long long stringToLL(const std::string &s)
         istr >> std::hex;
     else if (oct)
         istr >> std::oct;
-    istr >> ret;
+    if(!(istr >> ret))
+        throw std::runtime_error("invalid number");
     return ret;
 }
 
@@ -101,7 +102,8 @@ static unsigned long long stringToULL(const std::string &s)
         istr >> std::hex;
     else if (oct)
         istr >> std::oct;
-    istr >> ret;
+    if(!(istr >> ret))
+        throw std::runtime_error("invalid number");
     return ret;
 }
 


### PR DESCRIPTION
The first commit is a minimal fix for the evaluation of character literals with escape sequences in the most common cases.

It does not fix the issue for

1. universal character name escape sequences
2. prefixed character literals (L'...', u'...', U'...', u8'....')
3. the `\e` GNU extension

I made the use of an unsupported escape sequence, including 1. and 3., fatal. I am not sure whether this is preferred over an incorrect integer representation.

For 2. a wrong representation is still used. I intended to partially implement 2., but it seems that the prefixed literals never make it to `simplifyNumbers`, so it might be more complicated.

For multicharacter literals all but the first one are ignored. That doesn't match the behavior of typical implementations, but is, I think, standard-conform.

Following the code already present, character values are determined by the host execution character set and wrapped/truncated to the `0` - `255` range. This implies an unsigned `char` type. I am not sure whether/how I should take `char` signedness into account. It might make sense to make out-of-range values fatal instead.

The second commit makes conditions in which an expected number can not be read fatal. I introduced it to make `\x` without any digits or too many digits fatal. Again I am not sure whether this is preferred and this change in particular might have effects that I didn't anticipate.

TODO: Add test cases.