### PR TITLE
Support some more GCC extensions for character literals

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2402,6 +2402,12 @@ long long simplecpp::characterLiteralToLL(const std::string& str)
                 throw std::runtime_error("unexpected end of character literal");
 
             switch (escape) {
+            // obscure GCC extensions
+            case '%':
+            case '(':
+            case '[':
+            case '{':
+            // standard escape sequences
             case '\'':
             case '"':
             case '?':
@@ -2431,8 +2437,9 @@ long long simplecpp::characterLiteralToLL(const std::string& str)
                 value = static_cast<unsigned char>('\v');
                 break;
 
-            // ESC extension
+            // GCC extension for ESC character
             case 'e':
+            case 'E':
                 value = static_cast<unsigned char>('\x1b');
                 break;
 

--- a/test.cpp
+++ b/test.cpp
@@ -172,7 +172,15 @@ static void characterLiteral()
     ASSERT_EQUALS('\t', simplecpp::characterLiteralToLL("'\\t'"));
     ASSERT_EQUALS('\v', simplecpp::characterLiteralToLL("'\\v'"));
 
+    // GCC extension for ESC character
     ASSERT_EQUALS(0x1b, simplecpp::characterLiteralToLL("'\\e'"));
+    ASSERT_EQUALS(0x1b, simplecpp::characterLiteralToLL("'\\E'"));
+    
+    // more obscure GCC extensions
+    ASSERT_EQUALS('(', simplecpp::characterLiteralToLL("'\\('"));
+    ASSERT_EQUALS('[', simplecpp::characterLiteralToLL("'\\['"));
+    ASSERT_EQUALS('{', simplecpp::characterLiteralToLL("'\\{'"));
+    ASSERT_EQUALS('%', simplecpp::characterLiteralToLL("'\\%'"));
 
     ASSERT_EQUALS('\0',   simplecpp::characterLiteralToLL("'\\0'"));
     ASSERT_EQUALS('\1',   simplecpp::characterLiteralToLL("'\\1'"));


### PR DESCRIPTION
This fixes daca reports such as
```
tracetuner_3.0.6beta/src/mkchk/checkbcphd.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL('\%') => invalid escape sequence [cppcheckError]
xview-3.2p1.4/util/xgettext/xgettext.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL('\(') => invalid escape sequence [cppcheckError]
afterstep-devel-2.2.12/libAfterConf/Color.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL('\{') => invalid escape sequence [cppcheckError]
NetworkManager-1.30.0/src/core/settings/plugins/ifcfg-rh/shvar.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL('\E') => invalid escape sequence [cppcheckError]
```
which use extensions that are supported by both GCC and Clang.

This does not fix the following report which is also accepted by GCC, but not Clang:
```
sparse-0.6.3/validation/escapes.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL('\x7890') => numeric escape sequence too large [cppcheckError]
```
The behavior of this literal in GCC is a bit weird, resulting in `-0x70` if `char` is signed and `0x90` otherwise. According to the standard it is a contraint violation. I suppose it is more likely that this is written unintentionally, so I think an error message isn't too bad.

Both Clang and GCC also accept invalid literals like `'\z'` with a warning, interpreting them by simply dropping the backslash. I did not add this behavior, because there wasn't any daca report for them so far.

I think all of these extensions should result in a portability report, but I don't see any mechanism to signal that to the caller of `characterLiteralToLL` at the moment.
