### PR TITLE
Basic support for UTF-8 source in character literals

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2334,10 +2334,11 @@ static unsigned long long stringToULLbounded(
 /* Converts character literal (including prefix, but not ud-suffix)
  * to long long value.
  *
- * Assumes ASCII-compatible single-byte encoded str.
+ * Assumes ASCII-compatible single-byte encoded str for narrow literals
+ * and UTF-8 otherwise.
  *
  * For target assumes
- * - UTF-8 execution character set encoding or encoding matching str
+ * - execution character set encoding matching str
  * - UTF-32 execution wide-character set encoding
  * - requirements for __STDC_UTF_16__, __STDC_UTF_32__ and __STDC_ISO_10646__ satisfied
  * - char16_t is 16bit wide
@@ -2476,8 +2477,39 @@ long long simplecpp::characterLiteralToLL(const std::string& str)
         } else {
             value = static_cast<unsigned char>(str[pos++]);
 
-            if (!narrow && value > 0x7f)
-                throw std::runtime_error("non-ASCII source characters supported only in narrow character literals");
+            if (!narrow && value >= 0x80) {
+                // Assuming this is a UTF-8 encoded code point.
+                // This decoder does not completely validate the input, for example it doesn't reject overlong encodings.
+                
+                int additional_bytes;
+                if (value >= 0xf8)
+                    throw std::runtime_error("assumed UTF-8 encoded source, but sequence is invalid");
+                else if (value >= 0xf0)
+                    additional_bytes = 3;
+                else if (value >= 0xe0)
+                    additional_bytes = 2;
+                else if (value >= 0xc0)
+                    additional_bytes = 1;
+                else
+                    throw std::runtime_error("assumed UTF-8 encoded source, but sequence is invalid");
+                
+                value &= (1 << (6 - additional_bytes)) - 1;
+
+                while (additional_bytes--) {
+                    if(pos + 1 >= str.size())
+                        throw std::runtime_error("assumed UTF-8 encoded source, but character literal ends unexpectedly");
+                    unsigned char c = str[pos++];
+                    if((c >> 6) != 2) // ensure c has form 0xb10xxxxxx
+                        throw std::runtime_error("assumed UTF-8 encoded source, but sequence is invalid");
+                    value = (value << 6) | (c & ((1 << 7) - 1));
+                }
+
+                if ((value >= 0xd800 && value <= 0xdfff) || value > 0x10ffff)
+                    throw std::runtime_error("assumed UTF-8 encoded source, but sequence is invalid");
+                
+                if (((narrow || utf8) && value > 0x7f) || (utf16 && value > 0xffff) || value > 0x10ffff)
+                    throw std::runtime_error("code point too large");
+            }
         }
 
         if (((narrow || utf8) && value > std::numeric_limits<unsigned char>::max()) || (utf16 && value >> 16) || value >> 32)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2504,10 +2504,10 @@ long long simplecpp::characterLiteralToLL(const std::string& str)
                     value = (value << 6) | (c & ((1 << 7) - 1));
                 }
 
-                if ((value >= 0xd800 && value <= 0xdfff) || value > 0x10ffff)
+                if (value >= 0xd800 && value <= 0xdfff)
                     throw std::runtime_error("assumed UTF-8 encoded source, but sequence is invalid");
                 
-                if (((narrow || utf8) && value > 0x7f) || (utf16 && value > 0xffff) || value > 0x10ffff)
+                if ((utf8 && value > 0x7f) || (utf16 && value > 0xffff) || value > 0x10ffff)
                     throw std::runtime_error("code point too large");
             }
         }

--- a/test.cpp
+++ b/test.cpp
@@ -225,6 +225,69 @@ static void characterLiteral()
 #endif
 
     ASSERT_THROW(simplecpp::characterLiteralToLL("'\\9'"), std::runtime_error);
+    
+    // Input is manually encoded to (escaped) UTF-8 byte sequences
+    // to avoid dependence on source encoding used for this file
+    ASSERT_EQUALS(0xb5, simplecpp::characterLiteralToLL("U'\302\265'"));
+    ASSERT_EQUALS(0x157, simplecpp::characterLiteralToLL("U'\305\227'"));
+    ASSERT_EQUALS(0xff0f, simplecpp::characterLiteralToLL("U'\357\274\217'"));
+    ASSERT_EQUALS(0x3042, simplecpp::characterLiteralToLL("U'\343\201\202'"));
+    ASSERT_EQUALS(0x13000, simplecpp::characterLiteralToLL("U'\360\223\200\200'"));
+    
+    ASSERT_EQUALS(0xb5, simplecpp::characterLiteralToLL("L'\302\265'"));
+    ASSERT_EQUALS(0x157, simplecpp::characterLiteralToLL("L'\305\227'"));
+    ASSERT_EQUALS(0xff0f, simplecpp::characterLiteralToLL("L'\357\274\217'"));
+    ASSERT_EQUALS(0x3042, simplecpp::characterLiteralToLL("L'\343\201\202'"));
+    ASSERT_EQUALS(0x13000, simplecpp::characterLiteralToLL("L'\360\223\200\200'"));
+    
+    ASSERT_EQUALS(0xb5, simplecpp::characterLiteralToLL("u'\302\265'"));
+    ASSERT_EQUALS(0x157, simplecpp::characterLiteralToLL("u'\305\227'"));
+    ASSERT_EQUALS(0xff0f, simplecpp::characterLiteralToLL("u'\357\274\217'"));
+    ASSERT_EQUALS(0x3042, simplecpp::characterLiteralToLL("u'\343\201\202'"));
+    ASSERT_THROW(simplecpp::characterLiteralToLL("u'\360\223\200\200'"), std::runtime_error);
+    
+    ASSERT_THROW(simplecpp::characterLiteralToLL("u8'\302\265'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("u8'\305\227'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("u8'\357\274\217'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("u8'\343\201\202'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("u8'\360\223\200\200'"), std::runtime_error);
+    
+    ASSERT_EQUALS('\x89', simplecpp::characterLiteralToLL("'\x89'"));
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\x89'"), std::runtime_error);
+
+    // following examples based on https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+    ASSERT_EQUALS(0x80, simplecpp::characterLiteralToLL("U'\xc2\x80'"));
+    ASSERT_EQUALS(0x800, simplecpp::characterLiteralToLL("U'\xe0\xa0\x80'"));
+    ASSERT_EQUALS(0x10000, simplecpp::characterLiteralToLL("U'\xf0\x90\x80\x80'"));
+    
+    ASSERT_EQUALS(0x7f, simplecpp::characterLiteralToLL("U'\x7f'"));
+    ASSERT_EQUALS(0x7ff, simplecpp::characterLiteralToLL("U'\xdf\xbf'"));
+    ASSERT_EQUALS(0xffff, simplecpp::characterLiteralToLL("U'\xef\xbf\xbf'"));
+
+    ASSERT_EQUALS(0xd7ff, simplecpp::characterLiteralToLL("U'\xed\x9f\xbf'"));
+    ASSERT_EQUALS(0xe000, simplecpp::characterLiteralToLL("U'\xee\x80\x80'"));
+    ASSERT_EQUALS(0xfffd, simplecpp::characterLiteralToLL("U'\xef\xbf\xbd'"));
+    ASSERT_EQUALS(0x10ffff, simplecpp::characterLiteralToLL("U'\xf4\x8f\xbf\xbf'"));
+
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\x80'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\x80\x8f'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\x80\x8f\x8f'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\x80\x8f\x8f\x8f'"), std::runtime_error);
+    
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xbf'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xbf\x8f'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xbf\x8f\x8f'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xbf\x8f\x8f\x8f'"), std::runtime_error);
+
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xc0'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xc0 '"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xe0\x8f'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xe0\x8f '"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xf0\x8f\x8f'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xf0\x8f\x8f '"), std::runtime_error);
+    
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xf8'"), std::runtime_error);
+    ASSERT_THROW(simplecpp::characterLiteralToLL("U'\xff'"), std::runtime_error);
 }
 
 static void combineOperators_floatliteral()


### PR DESCRIPTION
This should resolve most daca reports of the following kinds:
```
head glibc-2.31/libio/tst-ftell-partial-wide.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL(L'\343\201\224') => non-ASCII source characters supported only in narrow character literals [cppcheckError]
head foot-1.6.4/main.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL(U'\303\266') => non-ASCII source characters supported only in narrow character literals [cppcheckError]
head icu/source/i18n/formatted_string_builder.cpp:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL(u'') => non-ASCII source characters supported only in narrow character literals [cppcheckError]
```
by assuming that non-narrow literals are passed to `characterLiteralToLL` encoded in UTF-8. This is in contrast with the handling of narrow literals, for which we assume a single-byte ASCII-compatible encoding for compatibility with source files in non-unicode character sets.

Ideally the source file is correctly decoded earlier in the process, but this should give correct results in the most common cases. It may however result in incorrect values if the assumed encodings are not correct.

I am not sure whether adding this extra complexity to simplecpp itself is worth it, especially since it is just a half-measure to the problem, but I felt like trying to write this and so I am suggesting it now.

As suggested in other discussion, an alternative would be to simply not assign values in these cases, continue failing if this happens during preprocessing (unlikely) and for integration in cppcheck signal an invalid value, since cppcheck isn't reliant on all of the values being present, but I don't know how I would implement this signalling in cppcheck.