### PR TITLE
Fix ## with multiple tokens in macro argument.

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1612,7 +1612,7 @@ namespace simplecpp {
                         TokenList new_output(files);
                         if (!expandArg(&new_output, tok, parametertokens2))
                             output->push_back(newMacroToken(tok->str(), loc, isReplaced(expandedmacros)));
-                        else if (new_output.empty()) // placeholder token
+                        else if (new_output.empty()) // placemarker token
                             output->push_back(newMacroToken("", loc, isReplaced(expandedmacros)));
                         else
                             for (const Token *tok2 = new_output.cfront(); tok2; tok2 = tok2->next)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1609,7 +1609,14 @@ namespace simplecpp {
                     if (sameline(tok, tok->next) && tok->next && tok->next->op == '#' && tok->next->next && tok->next->next->op == '#') {
                         if (!sameline(tok, tok->next->next->next))
                             throw invalidHashHash(tok->location, name());
-                        output->push_back(newMacroToken(expandArgStr(tok, parametertokens2), loc, isReplaced(expandedmacros)));
+                        TokenList new_output(files);
+                        if (!expandArg(&new_output, tok, parametertokens2))
+                            output->push_back(newMacroToken(tok->str(), loc, isReplaced(expandedmacros)));
+                        else if (new_output.empty()) // placeholder token
+                            output->push_back(newMacroToken("", loc, isReplaced(expandedmacros)));
+                        else
+                            for (const Token *tok2 = new_output.cfront(); tok2; tok2 = tok2->next)
+                                output->push_back(newMacroToken(tok2->str(), loc, isReplaced(expandedmacros)));
                         tok = tok->next;
                     } else {
                         tok = expandToken(output, loc, tok, macros, expandedmacros, parametertokens2);
@@ -1809,23 +1816,6 @@ namespace simplecpp {
                 }
             }
             return true;
-        }
-
-        /**
-         * Get string for token. If token is argument, the expanded string is returned.
-         * @param tok              The token
-         * @param parametertokens  parameters given when expanding this macro
-         * @return string
-         */
-        std::string expandArgStr(const Token *tok, const std::vector<const Token *> &parametertokens) const {
-            TokenList tokens(files);
-            if (expandArg(&tokens, tok, parametertokens)) {
-                std::string s;
-                for (const Token *tok2 = tokens.cfront(); tok2; tok2 = tok2->next)
-                    s += tok2->str();
-                return s;
-            }
-            return tok->str();
         }
 
         /**

--- a/test.cpp
+++ b/test.cpp
@@ -1016,6 +1016,13 @@ static void hashhash12()
     }
 }
 
+static void hashhash13()
+{
+    const char code[] = "#define X(x) x##U\n"
+                        "X((1<<1)-1)";
+    ASSERT_EQUALS("\n( 1 << 1 ) - 1U", preprocess(code));
+}
+
 static void hashhash_invalid_1()
 {
     std::istringstream istr("#define  f(a)  (##x)\nf(1)");
@@ -2238,6 +2245,7 @@ int main(int argc, char **argv)
     TEST_CASE(hashhash10); // #108 : #define x # #
     TEST_CASE(hashhash11); // #60: #define x # # #
     TEST_CASE(hashhash12);
+    TEST_CASE(hashhash13);
     TEST_CASE(hashhash_invalid_1);
     TEST_CASE(hashhash_invalid_2);
 

--- a/test.cpp
+++ b/test.cpp
@@ -1021,6 +1021,10 @@ static void hashhash13()
     const char code[] = "#define X(x) x##U\n"
                         "X((1<<1)-1)";
     ASSERT_EQUALS("\n( 1 << 1 ) - 1U", preprocess(code));
+    
+    const char code2[] = "#define CONCAT(x, y) x##y\n"
+                        "CONCAT(&a, b)";
+    ASSERT_EQUALS("\n& ab", preprocess(code2));
 }
 
 static void hashhash_invalid_1()


### PR DESCRIPTION
Only the last token in the argument token sequence substituted in front
of a ## should be concatenated. Previously the argument token sequence
was interpreted as a single token and concatenated.

Fixes #202.