### PR TITLE
only stringify the last line in `TokenList::readfile()` if necessary 

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -509,6 +509,8 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
 
             if (oldLastToken != cback()) {
                 oldLastToken = cback();
+                if (!isLastLinePreprocessor())
+                    continue;
                 const std::string lastline(lastLine());
                 if (lastline == "# file %str%") {
                     const Token *strtok = cback();
@@ -1221,6 +1223,22 @@ std::string simplecpp::TokenList::lastLine(int maxsize) const
             ret.insert(0, tok->str());
     }
     return ret;
+}
+
+bool simplecpp::TokenList::isLastLinePreprocessor(int maxsize) const
+{
+    const Token* prevTok = nullptr;
+    int count = 0;
+    for (const Token *tok = cback(); ; tok = tok->previous) {
+        if (!sameline(tok, cback()))
+            break;
+        if (tok->comment)
+            continue;
+        if (++count > maxsize)
+            return false;
+        prevTok = tok;
+    }
+    return prevTok && prevTok->str()[0] == '#';
 }
 
 unsigned int simplecpp::TokenList::fileIndex(const std::string &filename)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1203,15 +1203,22 @@ std::string simplecpp::TokenList::lastLine(int maxsize) const
 {
     std::string ret;
     int count = 0;
-    for (const Token *tok = cback(); sameline(tok,cback()); tok = tok->previous) {
+    for (const Token *tok = cback(); ; tok = tok->previous) {
+        if (!sameline(tok, cback())) {
+            break;
+        }
         if (tok->comment)
             continue;
         if (++count > maxsize)
             return "";
         if (!ret.empty())
             ret.insert(0, 1, ' ');
-        ret.insert(0, tok->str()[0] == '\"' ? std::string("%str%")
-                   : tok->number ? std::string("%num%") : tok->str());
+        if (tok->str()[0] == '\"')
+            ret.insert(0, "%str%");
+        else if (tok->number)
+            ret.insert(0, "%num%");
+        else
+            ret.insert(0, tok->str());
     }
     return ret;
 }

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -283,6 +283,7 @@ namespace simplecpp {
         void lineDirective(unsigned int fileIndex, unsigned int line, Location *location);
 
         std::string lastLine(int maxsize=100000) const;
+        bool isLastLinePreprocessor(int maxsize=100000) const;
 
         unsigned int fileIndex(const std::string &filename);
 


### PR DESCRIPTION
`lastLine()` is only used to check for preprocessor directives. So if it isn't such there's no need to stringify it saving a lot of unnecessary `std::string` operations.

The intermediate increase comes from not constructing `std::string` objects on-the-fly for `std::string::insert()` and simply using the literals.

Testing with `-q -Ilib/ -D__GNUC__ lib/valueflow.cpp` this saves about 8% of total Ir.

Clang 13 `298,836,106` -> `295,950,055` -> `267,545,621`
GCC 11 `305,058,160` -> `299,749,788` -> `271,347,737`