### PR TITLE
fixed Cppcheck compilation with MSBuild

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -58,12 +58,14 @@ static bool isOct(const std::string &s)
     return s.size()>1 && (s[0]=='0') && (s[1] >= '0') && (s[1] < '8');
 }
 
-static bool isStringLiteral(const std::string &s)
+// TODO: added an undercore since this conflicts with a function of the same name in utils.h from Cppcheck source when building Cppcheck with MSBuild
+static bool isStringLiteral_(const std::string &s)
 {
     return s.size() > 1 && (s[0]=='\"') && (*s.rbegin()=='\"');
 }
 
-static bool isCharLiteral(const std::string &s)
+// TODO: added an undercore since this conflicts with a function of the same name in utils.h from Cppcheck source when building Cppcheck with MSBuild
+static bool isCharLiteral_(const std::string &s)
 {
     // char literal patterns can include 'a', '\t', '\000', '\xff', 'abcd', and maybe ''
     // This only checks for the surrounding '' but doesn't parse the content.
@@ -1950,7 +1952,7 @@ namespace simplecpp {
                 throw invalidHashHash::unexpectedNewline(tok->location, name());
 
             bool canBeConcatenatedWithEqual = A->isOneOf("+-*/%&|^") || A->str() == "<<" || A->str() == ">>";
-            bool canBeConcatenatedStringOrChar = isStringLiteral(A->str()) || isCharLiteral(A->str());
+            bool canBeConcatenatedStringOrChar = isStringLiteral_(A->str()) || isCharLiteral_(A->str());
             if (!A->name && !A->number && A->op != ',' && !A->str().empty() && !canBeConcatenatedWithEqual && !canBeConcatenatedStringOrChar)
                 throw invalidHashHash::unexpectedToken(tok->location, name(), A);
 

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -353,10 +353,10 @@ namespace simplecpp {
     SIMPLECPP_LIB std::string convertCygwinToWindowsPath(const std::string &cygwinPath);
 
     /** Returns the __STDC_VERSION__ value for a given standard */
-    SIMPLECPP_LIB static std::string getCStdString(const std::string &std);
+    SIMPLECPP_LIB std::string getCStdString(const std::string &std);
 
     /** Returns the __cplusplus value for a given standard */
-    SIMPLECPP_LIB static std::string getCppStdString(const std::string &std);
+    SIMPLECPP_LIB std::string getCppStdString(const std::string &std);
 }
 
 #if (__cplusplus < 201103L) && !defined(__APPLE__)


### PR DESCRIPTION
I had to use the Visual Studio IDE to build it to get these issues. They did not happen when using CMake. This could also indicate that the configuration of the CMake Visual Studio build does not match the existing VS project files. Something to look into when we get ready to drop the VS project files.

This removes the `static` specifiers I incorrectly added to some new function in the `simplecpp` name in a58ae6283b9b62ba694034576707c612c3cbce6b. I somehow assumed those are class members.

The issue with duplicated function definitions of `isStringLiteral` and `isCharLiteral` appears to be a compiler bug. There's functions of the same name in `utils.h` in the Cppcheck source. These functions can never see each other but somehow the compiler has a problem with it. See https://youtrack.jetbrains.com/issue/RIDER-64723 for a report on this. This also needs to be reported upstream.