### PR TITLE
reduced padding in `simplecpp::Macro`

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1276,7 +1276,7 @@ namespace simplecpp {
 
     class Macro {
     public:
-        explicit Macro(std::vector<std::string> &f) : nameTokDef(nullptr), variadic(false), valueToken(nullptr), endToken(nullptr), files(f), tokenListDefine(f), valueDefinedInCode_(false) {}
+        explicit Macro(std::vector<std::string> &f) : nameTokDef(nullptr), valueToken(nullptr), endToken(nullptr), files(f), tokenListDefine(f), variadic(false), valueDefinedInCode_(false) {}
 
         Macro(const Token *tok, std::vector<std::string> &f) : nameTokDef(nullptr), files(f), tokenListDefine(f), valueDefinedInCode_(true) {
             if (sameline(tok->previous, tok))
@@ -2063,9 +2063,6 @@ namespace simplecpp {
         /** arguments for macro */
         std::vector<TokenString> args;
 
-        /** is macro variadic? */
-        bool variadic;
-
         /** first token in replacement string */
         const Token *valueToken;
 
@@ -2080,6 +2077,9 @@ namespace simplecpp {
 
         /** usage of this macro */
         mutable std::list<Location> usageList;
+
+        /** is macro variadic? */
+        bool variadic;
 
         /** was the value of this macro actually defined in the code? */
         bool valueDefinedInCode_;


### PR DESCRIPTION
Before:
```
simplecpp.cpp:2070:22: warning: padding class 'simplecpp::Macro' with 7 bytes to align 'valueToken' [-Wpadded]
simplecpp.cpp:1277:11: warning: padding size of 'simplecpp::Macro' with 7 bytes to alignment boundary [-Wpadded]
```

After:
```
simplecpp.cpp:1278:11: warning: padding size of 'simplecpp::Macro' with 6 bytes to alignment boundary [-Wpadded]
```