### PR TITLE
fail the `clang-tidy` build step in case of compiler warnings / ignor…

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Clang-Tidy
         run: |
-          run-clang-tidy-14 -q -j $(nproc) -p=cmake.output -extra-arg=-w
+          run-clang-tidy-14 -q -j $(nproc) -p=cmake.output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # these are not really fixable
     add_compile_options(-Wno-exit-time-destructors -Wno-global-constructors)
     # we are not interested in these
-    add_compile_options(-Wno-multichar)
+    add_compile_options(-Wno-multichar -Wno-four-char-constants)
     # TODO: fix these?
-    add_compile_options(-Wno-padded -Wno-sign-conversion -Wno-implicit-int-conversion -Wno-shorten-64-to-32)
+    add_compile_options(-Wno-padded -Wno-sign-conversion -Wno-implicit-int-conversion -Wno-shorten-64-to-32 -Wno-shadow-field-in-constructor)
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 14)
         # not all tools support DWARF 5 yet so stick to version 4


### PR DESCRIPTION
…e `-Wfour-char-constants` and temporally disable `-Wshadow-field-in-constructor` clang warnings