### PR TITLE
avoid some implicit conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # we are not interested in these
     add_compile_options(-Wno-multichar -Wno-four-char-constants)
     # TODO: fix these?
-    add_compile_options(-Wno-padded -Wno-sign-conversion -Wno-implicit-int-conversion -Wno-shadow-field-in-constructor)
+    add_compile_options(-Wno-padded -Wno-sign-conversion -Wno-shadow-field-in-constructor)
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 14 OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
         # TODO: verify this regression still exists in clang-15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,6 @@ endif()
 
 add_executable(testrunner $<TARGET_OBJECTS:simplecpp_obj> test.cpp)
 set_property(TARGET testrunner PROPERTY CXX_STANDARD 11)
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(testrunner PRIVATE -Wno-shorten-64-to-32)
-endif()
 
 enable_testing()
 add_test(NAME testrunner COMMAND testrunner)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # we are not interested in these
     add_compile_options(-Wno-multichar -Wno-four-char-constants)
     # TODO: fix these?
-    add_compile_options(-Wno-padded -Wno-sign-conversion -Wno-implicit-int-conversion -Wno-shorten-64-to-32 -Wno-shadow-field-in-constructor)
+    add_compile_options(-Wno-padded -Wno-sign-conversion -Wno-implicit-int-conversion -Wno-shadow-field-in-constructor)
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 14 OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
         # TODO: verify this regression still exists in clang-15
@@ -50,6 +50,9 @@ endif()
 
 add_executable(testrunner $<TARGET_OBJECTS:simplecpp_obj> test.cpp)
 set_property(TARGET testrunner PROPERTY CXX_STANDARD 11)
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(testrunner PRIVATE -Wno-shorten-64-to-32)
+endif()
 
 enable_testing()
 add_test(NAME testrunner COMMAND testrunner)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -540,7 +540,7 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                     const Token *numtok = cback();
                     while (numtok->comment)
                         numtok = numtok->previous;
-                    lineDirective(location.fileIndex, std::atol(numtok->str().c_str()), &location);
+                    lineDirective(location.fileIndex, static_cast<unsigned int>(std::atol(numtok->str().c_str())), &location);
                 } else if (lastline == "# %num% %str%" || lastline == "# line %num% %str%") {
                     const Token *strtok = cback();
                     while (strtok->comment)
@@ -549,7 +549,7 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                     while (numtok->comment)
                         numtok = numtok->previous;
                     lineDirective(fileIndex(replaceAll(strtok->str().substr(1U, strtok->str().size() - 2U),"\\\\","\\")),
-                                  std::atol(numtok->str().c_str()), &location);
+                                  static_cast<unsigned int>(std::atol(numtok->str().c_str())), &location);
                 }
                 // #endfile
                 else if (lastline == "# endfile" && !loc.empty()) {
@@ -1265,7 +1265,7 @@ unsigned int simplecpp::TokenList::fileIndex(const std::string &filename)
             return i;
     }
     files.push_back(filename);
-    return files.size() - 1U;
+    return static_cast<unsigned int>(files.size() - 1U);
 }
 
 

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -400,7 +400,7 @@ static unsigned short getAndSkipBOM(std::istream &istr)
 
     // The UTF-16 BOM is 0xfffe or 0xfeff.
     if (ch1 >= 0xfe) {
-        const unsigned short bom = (static_cast<unsigned char>(istr.get()) << 8);
+        const unsigned short bom = static_cast<unsigned short>((static_cast<unsigned char>(istr.get()) << 8));
         if (istr.peek() >= 0xfe)
             return bom | static_cast<unsigned char>(istr.get());
         istr.unget();
@@ -779,7 +779,7 @@ static bool isFloatSuffix(const simplecpp::Token *tok)
 {
     if (!tok || tok->str().size() != 1U)
         return false;
-    const char c = std::tolower(tok->str()[0]);
+    const char c = static_cast<char>(std::tolower(tok->str()[0]));
     return c == 'f' || c == 'l';
 }
 
@@ -2100,11 +2100,11 @@ namespace simplecpp {
             const unsigned char driveLetter = cygwinPath[10];
             if (std::isalpha(driveLetter)) {
                 if (cygwinPath.size() == 11) {
-                    windowsPath = toupper(driveLetter);
+                    windowsPath = static_cast<char>(toupper(driveLetter));
                     windowsPath += ":\\";   // volume root directory
                     pos = 11;
                 } else if (cygwinPath[11] == '/') {
-                    windowsPath = toupper(driveLetter);
+                    windowsPath = static_cast<char>(toupper(driveLetter));
                     windowsPath += ":";
                     pos = 11;
                 }

--- a/test.cpp
+++ b/test.cpp
@@ -50,7 +50,7 @@ static int assertEquals(const std::string &expected, const std::string &actual, 
     return (expected == actual);
 }
 
-static int assertEquals(const unsigned int &expected, const unsigned int &actual, int line)
+static int assertEquals(const unsigned long long &expected, const unsigned long long &actual, int line)
 {
     return assertEquals(std::to_string(expected), std::to_string(actual), line);
 }


### PR DESCRIPTION
This does not change any types. It just makes implicit conversions explicit.

Here's the warnings in question for reference:
```
/mnt/s/GitHub/simplecpp-fw/simplecpp.cpp:401:76: warning: implicit conversion loses integer precision: 'int' to 'const unsigned short' [-Wimplicit-int-conversion]
        const unsigned short bom = (static_cast<unsigned char>(istr.get()) << 8);
                             ~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/mnt/s/GitHub/simplecpp-fw/simplecpp.cpp:541:55: warning: implicit conversion loses integer precision: 'long' to 'unsigned int' [-Wshorten-64-to-32]
                    lineDirective(location.fileIndex, std::atol(numtok->str().c_str()), &location);
                    ~~~~~~~~~~~~~                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/s/GitHub/simplecpp-fw/simplecpp.cpp:550:35: warning: implicit conversion loses integer precision: 'long' to 'unsigned int' [-Wshorten-64-to-32]
                                  std::atol(numtok->str().c_str()), &location);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/s/GitHub/simplecpp-fw/simplecpp.cpp:780:20: warning: implicit conversion loses integer precision: 'int' to 'const char' [-Wimplicit-int-conversion]
    const char c = std::tolower(tok->str()[0]);
               ~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/s/GitHub/simplecpp-fw/simplecpp.cpp:1266:25: warning: implicit conversion loses integer precision: 'unsigned long' to 'unsigned int' [-Wshorten-64-to-32]
    return files.size() - 1U;
    ~~~~~~ ~~~~~~~~~~~~~^~~~
/mnt/s/GitHub/simplecpp-fw/simplecpp.cpp:2101:35: warning: implicit conversion loses integer precision: 'int' to 'char' [-Wimplicit-int-conversion]
                    windowsPath = toupper(driveLetter);
                                ~ ^~~~~~~~~~~~~~~~~~~~
/mnt/s/GitHub/simplecpp-fw/simplecpp.cpp:2105:35: warning: implicit conversion loses integer precision: 'int' to 'char' [-Wimplicit-int-conversion]
                    windowsPath = toupper(driveLetter);
                                ~ ^~~~~~~~~~~~~~~~~~~~
```

And an example for the warnings with the assertions:
```
/mnt/s/GitHub/simplecpp-fw/test.cpp:1845:29: warning: implicit conversion loses integer precision: 'std::vector::size_type' (aka 'unsigned long') to 'const unsigned int' [-Wshorten-64-to-32]
    ASSERT_EQUALS(1U, files.size());
    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```