### PR TITLE
`TokenList` move constructor was also calling the copy constructor

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -242,7 +242,7 @@ simplecpp::TokenList::TokenList(const TokenList &other) : frontToken(nullptr), b
 }
 
 #if __cplusplus >= 201103L
-simplecpp::TokenList::TokenList(TokenList &&other) : TokenList(other)
+simplecpp::TokenList::TokenList(TokenList &&other) : frontToken(nullptr), backToken(nullptr), files(other.files)
 {
     *this = std::move(other);
 }


### PR DESCRIPTION
This reduces Ir in the proposed callgrind step in #4171 from `82,239,299,916` to `80,867,576,736` (some other optimizations were applied beforehand).