### PR TITLE
avoid unnecessary copy in `openHeader()` - detected by upcoming clang-tidy check `performance-unnecessary-copy-on-last-use`

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2862,11 +2862,15 @@ static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const
 
     if (systemheader) {
         ret = openHeaderIncludePath(f, dui, header);
-        return ret.empty() ? openHeaderRelative(f, sourcefile, header) : ret;
+        if (ret.empty())
+            return openHeaderRelative(f, sourcefile, header);
+        return ret;
     }
 
     ret = openHeaderRelative(f, sourcefile, header);
-    return ret.empty() ? openHeaderIncludePath(f, dui, header) : ret;
+    if (ret.empty())
+        openHeaderIncludePath(f, dui, header);
+    return ret;
 }
 
 static std::string getFileName(const std::map<std::string, simplecpp::TokenList *> &filedata, const std::string &sourcefile, const std::string &header, const simplecpp::DUI &dui, bool systemheader)


### PR DESCRIPTION
I looks like a false positive but using a non-POD variable in a ternary causes it to be copied - see https://reviews.llvm.org/D137205#3939210.

Since simplecpp also supports pre-C++11 standards `std:move()` could not be used and I refactored the code instead getting rid of the ternaries.