### PR TITLE
Includes of system headers are never implicitly relative to the source file

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2864,8 +2864,6 @@ static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const
 
     if (systemheader) {
         ret = openHeaderIncludePath(f, dui, header);
-        if (ret.empty())
-            return openHeaderRelative(f, sourcefile, header);
         return ret;
     }
 
@@ -2894,8 +2892,8 @@ static std::string getFileName(const std::map<std::string, simplecpp::TokenList 
             return s;
     }
 
-    if (filedata.find(relativeFilename) != filedata.end())
-        return relativeFilename;
+    if (systemheader && filedata.find(header) != filedata.end())
+        return header;
 
     return "";
 }
@@ -3223,7 +3221,7 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
 
                 const Token * const inctok = inc2.cfront();
 
-                const bool systemheader = (inctok->op == '<');
+                const bool systemheader = (inctok->str()[0] == '<');
                 const std::string header(realFilename(inctok->str().substr(1U, inctok->str().size() - 2U)));
                 std::string header2 = getFileName(filedata, rawtok->location.file(), header, dui, systemheader);
                 if (header2.empty()) {

--- a/test.cpp
+++ b/test.cpp
@@ -1653,6 +1653,22 @@ static void nestedInclude()
     ASSERT_EQUALS("file0,1,include_nested_too_deeply,#include nested too deeply\n", toString(outputList));
 }
 
+static void systemInclude()
+{
+    const char code[] = "#include <limits.h>\n";
+    std::vector<std::string> files;
+    simplecpp::TokenList rawtokens = makeTokenList(code,files,"local/limits.h");
+    std::map<std::string, simplecpp::TokenList*> filedata;
+    filedata["limits.h"] = nullptr;
+    filedata["local/limits.h"] = &rawtokens;
+
+    simplecpp::OutputList outputList;
+    simplecpp::TokenList tokens2(files);
+    simplecpp::preprocess(tokens2, rawtokens, files, filedata, simplecpp::DUI(), &outputList);
+
+    ASSERT_EQUALS("", toString(outputList));
+}
+
 static void multiline1()
 {
     const char code[] = "#define A \\\n"
@@ -2566,6 +2582,7 @@ int main(int argc, char **argv)
     TEST_CASE(missingHeader2);
     TEST_CASE(missingHeader3);
     TEST_CASE(nestedInclude);
+    TEST_CASE(systemInclude);
 
     TEST_CASE(nullDirective1);
     TEST_CASE(nullDirective2);


### PR DESCRIPTION
Sometimes, `#include` directives with angle-bracket filespec delimiters are used (or abused) to defeat the preprocessor's behaviour where it tries to find a header file at a path relative to the file containing the directive.

Without this fix, any non-root header file, `foo/bar.h`, which does
```c
  #include <bar.h>
```
while intending to include a root-level header file, will instead enter an infinite inclusion loop, terminating when the inclusion stack overflows with a `#include nested too deeply` error.

See also [this cppcheck issue](https://trac.cppcheck.net/ticket/7840).