### PR TITLE
CI-unixish.yml: specify proper define for "safe libc++"

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -46,7 +46,7 @@ jobs:
       if: matrix.os == 'ubuntu-22.04' && matrix.compiler == 'clang++'
       run: |
         make clean
-        make -j$(nproc) test CXX=${{ matrix.compiler }} CXXFLAGS="-stdlib=libc++ -g3 -DLIBCXX_ENABLE_DEBUG_MODE" LDFLAGS="-lc++"
+        make -j$(nproc) test CXX=${{ matrix.compiler }} CXXFLAGS="-stdlib=libc++ -g3 -D_LIBCPP_ENABLE_ASSERTIONS=1" LDFLAGS="-lc++"
 
     - name: Run AddressSanitizer
       if: matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
I followed the documentation from https://libcxx.llvm.org/DesignDocs/DebugMode.html#using-the-debug-mode which refers to `LIBCXX_ENABLE_DEBUG_MODE`. But that is a CMake define you are supposed to pass when building `libc++`. Also the debug mode needs the library to be built with it which is not something we do. So as suggested we should enable the assertions via `_LIBCPP_ENABLE_ASSERTIONS=1` instead - see https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode.