### PR TITLE
improved prerequisite checks for `__has_include` handling

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1980,7 +1980,7 @@ namespace simplecpp {
                             if (tok->next->str() == "(")
                               ++paren;
                             else if (tok->next->str() == ")")
-                              --paren;                            
+                              --paren;
                             if (paren == 0)
                               return tok->next->next;
                             tok = tok->next;
@@ -2614,6 +2614,12 @@ static void simplifySizeof(simplecpp::TokenList &expr, const std::map<std::strin
 }
 
 /** Evaluate __has_include(file) */
+static bool isCpp17OrLater(const simplecpp::DUI &dui)
+{
+    const std::string std_ver = simplecpp::getCppStdString(dui.std);
+    return !std_ver.empty() && (std_ver >= "201703L");
+}
+
 static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const std::string &sourcefile, const std::string &header, bool systemheader);
 static void simplifyHasInclude(simplecpp::TokenList &expr, const simplecpp::DUI &dui)
 {
@@ -3277,7 +3283,7 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
     // use a dummy vector for the macros because as this is not part of the file and would add an empty entry - e.g. /usr/include/poll.h
     std::vector<std::string> dummy;
 
-    const bool hasInclude = (dui.std.size() == 5 && dui.std.compare(0,3,"c++") == 0 && dui.std >= "c++17");
+    const bool hasInclude = isCpp17OrLater(dui);
     MacroMap macros;
     for (std::list<std::string>::const_iterator it = dui.defines.begin(); it != dui.defines.end(); ++it) {
         const std::string &macrostr = *it;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2623,6 +2623,9 @@ static bool isCpp17OrLater(const simplecpp::DUI &dui)
 static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const std::string &sourcefile, const std::string &header, bool systemheader);
 static void simplifyHasInclude(simplecpp::TokenList &expr, const simplecpp::DUI &dui)
 {
+    if (!isCpp17OrLater(dui))
+        return;
+
     for (simplecpp::Token *tok = expr.front(); tok; tok = tok->next) {
         if (tok->str() != HAS_INCLUDE)
             continue;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2618,7 +2618,7 @@ static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const
 static void simplifyHasInclude(simplecpp::TokenList &expr, const simplecpp::DUI &dui)
 {
     for (simplecpp::Token *tok = expr.front(); tok; tok = tok->next) {
-        if (tok->str() != "__has_include")
+        if (tok->str() != HAS_INCLUDE)
             continue;
         simplecpp::Token *tok1 = tok->next;
         if (!tok1) {


### PR DESCRIPTION
The check in `simplecpp::preprocess` obviously didn't work if `gnu++` or another alias were used. Also the simplification should only be performed if supported.

This does not fix the hang tracked in https://trac.cppcheck.net/ticket/11456. The code there is unfortunately a file which is over 1.5 MB big so we need to find a smaller sample.