### PR TITLE
added `DUI::clearIncludeCache` to clear the non-existing files cache

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2796,6 +2796,11 @@ public:
         m_pathSet.insert(path);
     }
 
+    void clear() {
+        ScopedLock lock(m_criticalSection);
+        m_pathSet.clear();
+    }
+
 private:
     std::set<std::string> m_pathSet;
     CRITICAL_SECTION m_criticalSection;
@@ -2907,6 +2912,11 @@ static bool hasFile(const std::map<std::string, simplecpp::TokenList *> &filedat
 
 std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::TokenList &rawtokens, std::vector<std::string> &filenames, const simplecpp::DUI &dui, simplecpp::OutputList *outputList)
 {
+#ifdef SIMPLECPP_WINDOWS
+    if (dui.clearIncludeCache)
+        nonExistingFilesCache .clear();
+#endif
+
     std::map<std::string, simplecpp::TokenList*> ret;
 
     std::list<const Token *> filelist;
@@ -3032,6 +3042,11 @@ static std::string getTimeDefine(struct tm *timep)
 
 void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenList &rawtokens, std::vector<std::string> &files, std::map<std::string, simplecpp::TokenList *> &filedata, const simplecpp::DUI &dui, simplecpp::OutputList *outputList, std::list<simplecpp::MacroUsage> *macroUsage, std::list<simplecpp::IfCond> *ifCond)
 {
+#ifdef SIMPLECPP_WINDOWS
+    if (dui.clearIncludeCache)
+        nonExistingFilesCache.clear();
+#endif
+
     std::map<std::string, std::size_t> sizeOfType(rawtokens.sizeOfType);
     sizeOfType.insert(std::make_pair("char", sizeof(char)));
     sizeOfType.insert(std::make_pair("short", sizeof(short)));

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2812,8 +2812,8 @@ static NonExistingFilesCache nonExistingFilesCache;
 
 static std::string openHeader(std::ifstream &f, const std::string &path)
 {
-#ifdef SIMPLECPP_WINDOWS
     std::string simplePath = simplecpp::simplifyPath(path);
+#ifdef SIMPLECPP_WINDOWS
     if (nonExistingFilesCache.contains(simplePath))
         return "";  // file is known not to exist, skip expensive file open call
 
@@ -2825,8 +2825,8 @@ static std::string openHeader(std::ifstream &f, const std::string &path)
         return "";
     }
 #else
-    f.open(path.c_str());
-    return f.is_open() ? simplecpp::simplifyPath(path) : "";
+    f.open(simplePath.c_str());
+    return f.is_open() ? simplePath : "";
 #endif
 }
 

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2816,18 +2816,14 @@ static std::string openHeader(std::ifstream &f, const std::string &path)
 #ifdef SIMPLECPP_WINDOWS
     if (nonExistingFilesCache.contains(simplePath))
         return "";  // file is known not to exist, skip expensive file open call
-
+#endif
     f.open(simplePath.c_str());
     if (f.is_open())
         return simplePath;
-    else {
-        nonExistingFilesCache.add(simplePath);
-        return "";
-    }
-#else
-    f.open(simplePath.c_str());
-    return f.is_open() ? simplePath : "";
+#ifdef SIMPLECPP_WINDOWS
+    nonExistingFilesCache.add(simplePath);
 #endif
+    return "";
 }
 
 static std::string getRelativeFileName(const std::string &sourcefile, const std::string &header)

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -314,12 +314,13 @@ namespace simplecpp {
      * On the command line these are configured by -D, -U, -I, --include, -std
      */
     struct SIMPLECPP_LIB DUI {
-        DUI() {}
+        DUI() : clearIncludeCache(false) {}
         std::list<std::string> defines;
         std::set<std::string> undefined;
         std::list<std::string> includePaths;
         std::list<std::string> includes;
         std::string std;
+        bool clearIncludeCache;
     };
 
     SIMPLECPP_LIB long long characterLiteralToLL(const std::string& str);


### PR DESCRIPTION
This necessary for the missing include tests in Cppcheck to work. As well for contexts where this exists across multiple scans - this currently lacks proper support in Cppcheck though.