### PR TITLE
added asserts to streams to make sure the input is valid

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -23,6 +23,7 @@
 #include "simplecpp.h"
 
 #include <algorithm>
+#include <cassert>
 #include <climits>
 #include <cstddef>
 #include <cstdlib>
@@ -351,6 +352,7 @@ public:
     StdIStream(std::istream &istr)
         : istr(istr)
     {
+        assert(istr.good());
         init();
     }
 
@@ -378,6 +380,7 @@ public:
         , lastCh(0)
         , lastStatus(0)
     {
+        assert(file != nullptr);
         init();
     }
 


### PR DESCRIPTION
This can never happen when you use the `Stream` classes within the regular simplecpp context. I checked the code that we always check the existence beforehand. But it might happen within the tests (see #261).