### PR TITLE
suppress msvc warnings about totally safe functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ endfunction()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     add_compile_options(-Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wshadow -Wundef -Wold-style-cast -Wno-multichar)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Weverything)
     # no need for c++98 compatibility

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -44,6 +44,12 @@
 #define nullptr NULL
 #endif
 
+#if defined(_WIN32)
+// suppress warnings about "conversion from 'type1' to 'type2', possible loss of data"
+#  pragma warning(disable : 4267)
+#  pragma warning(disable : 4244)
+#endif
+
 namespace simplecpp {
 
     typedef std::string TokenString;

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -44,7 +44,7 @@
 #define nullptr NULL
 #endif
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 // suppress warnings about "conversion from 'type1' to 'type2', possible loss of data"
 #  pragma warning(disable : 4267)
 #  pragma warning(disable : 4244)


### PR DESCRIPTION
Compiling with MSVC proves to be an unpleasant experience due to MSVC unreasonably complaining about the following:
It complains about this library using `fopen` instead of their CRT non-standard `fopen_s` function.
This warning cannot be suppressed by adding a definition to the `simplecpp.h` header, it does not work somehow. 
It is a bug I've always had with programs compiled with MSVC. I have always added `_CRT_SECURE_NO_WARNINGS` to the preached header but because this repository does not have one I have opted to add it to the CMAKE file.

Finally, the most annoying warnings are suppressed successfully using pragma directives.
Without these pragmas, my MSVC produces an immense build log full of warnings.
I hope this PR is appreciated in respect of: https://github.com/danmar/simplecpp/pull/288#issuecomment-1452562480