### PR TITLE
Do not confuse defines and designated initializers as float literals

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -926,7 +926,7 @@ void simplecpp::TokenList::combineOperators()
                 continue;
             }
             // float literals..
-            if (tok->previous && tok->previous->number) {
+            if (tok->previous && tok->previous->number && sameline(tok->previous, tok)) {
                 tok->setstr(tok->previous->str() + '.');
                 deleteToken(tok->previous);
                 if (isFloatSuffix(tok->next) || (tok->next && tok->next->startsWithOneOf("AaBbCcDdEeFfPp"))) {

--- a/test.cpp
+++ b/test.cpp
@@ -568,6 +568,23 @@ static void define11() // location of expanded argument
     ASSERT_EQUALS("\n#line 10 \"cppcheck.cpp\"\n1 ;", preprocess(code));
 }
 
+static void define12()
+{
+    const char code[] = "struct foo x = {\n"
+                        "  #define V 0\n"
+                        "  .x = V,\n"
+                        "};\n";
+    ASSERT_EQUALS("struct foo x = {\n"
+                  "# define V 0\n"
+                  ". x = V ,\n"
+                  "} ;", readfile(code));
+    ASSERT_EQUALS("struct foo x = {\n"
+                  "\n"
+                  ". x = 0 ,\n"
+                  "} ;", preprocess(code));
+}
+
+
 
 static void define_invalid_1()
 {
@@ -2617,6 +2634,7 @@ int main(int argc, char **argv)
     TEST_CASE(define9);
     TEST_CASE(define10);
     TEST_CASE(define11);
+    TEST_CASE(define12);
     TEST_CASE(define_invalid_1);
     TEST_CASE(define_invalid_2);
     TEST_CASE(define_define_1);


### PR DESCRIPTION
Should hopefully also fix #297.