### PR TITLE
inverted the relationship between expanded macros and tokens

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1708,7 +1708,7 @@ namespace simplecpp {
     private:
         /** Create new token where Token::macro is set for replaced tokens */
         Token *newMacroToken(const TokenString &str, const Location &loc, bool replaced, const Token *expandedFromToken=nullptr) const {
-            Token *tok = new Token(str,loc);
+            Token * const tok = new Token(str,loc);
             if (replaced)
                 tok->macro = nameTokDef->str();
             if (expandedFromToken)

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -172,16 +172,6 @@ namespace simplecpp {
             return tok;
         }
 
-        void setExpandedFrom(const Token *tok, const Macro* m) {
-            mExpandedFrom = tok->mExpandedFrom;
-            mExpandedFrom.insert(m);
-            if (tok->whitespaceahead)
-                whitespaceahead = true;
-        }
-        bool isExpandedFrom(const Macro* m) const {
-            return mExpandedFrom.find(m) != mExpandedFrom.end();
-        }
-
         void printAll() const;
         void printOut() const;
     private:

--- a/test.cpp
+++ b/test.cpp
@@ -892,6 +892,14 @@ static void define_define_23() // #403 crash (infinite recursion)
     ASSERT_EQUALS("\n\n\n\nYdieZ ( void ) ;", preprocess(code));
 }
 
+static void define_define_24()
+{
+    const char code[] = "#define A0(a, b)  ((a) + (b))\n"
+                        "#define A1(a, b)  ((a) > (b)) ? A0((a) - (b), (b)) : A0((b) - (a), (a))\n"
+                        "	A1(a, b);";
+    ASSERT_EQUALS("\n\n( ( a ) > ( b ) ) ? ( ( ( a ) - ( b ) ) + ( ( b ) ) ) : ( ( ( b ) - ( a ) ) + ( ( a ) ) ) ;", preprocess(code));
+}
+
 static void define_va_args_1()
 {
     const char code[] = "#define A(fmt...) dostuff(fmt)\n"
@@ -3382,6 +3390,7 @@ int main(int argc, char **argv)
     TEST_CASE(define_define_21);
     TEST_CASE(define_define_22); // #400
     TEST_CASE(define_define_23); // #403 - crash, infinite recursion
+    TEST_CASE(define_define_24);
     TEST_CASE(define_va_args_1);
     TEST_CASE(define_va_args_2);
     TEST_CASE(define_va_args_3);


### PR DESCRIPTION
Instead of duplicating the macro references into each token we should just keep references to the tokens in the macros.