### PR TITLE
.clang-tidy: enabled `performance-move-constructor-init`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,6 @@ Checks: >
         -readability-uppercase-literal-suffix,
         -performance-avoid-endl,
         -performance-inefficient-string-concatenation,
-        -performance-move-constructor-init,
         -performance-no-automatic-move,
         -performance-noexcept-move-constructor
 HeaderFilterRegex: '.*'


### PR DESCRIPTION
I still had this in a branch with the accompanied fixes. But there no longer is a warning so I guess I already fixed that in one of my previous commits.