### PR TITLE
refs #352 - generate output error on unknown `DUI::std` value

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -169,6 +169,9 @@ int main(int argc, char **argv)
             case simplecpp::Output::FILE_NOT_FOUND:
                 std::cerr << "file not found: ";
                 break;
+            case simplecpp::Output::DUI_ERROR:
+                std::cerr << "dui error: ";
+                break;
             }
             std::cerr << output.msg << std::endl;
         }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3315,8 +3315,17 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
             macros.insert(std::make_pair("__STDC_VERSION__", Macro("__STDC_VERSION__", std_def, dummy)));
         } else {
             std_def = simplecpp::getCppStdString(dui.std);
-            if (!std_def.empty())
-                macros.insert(std::make_pair("__cplusplus", Macro("__cplusplus", std_def, dummy)));
+            if (std_def.empty()) {
+                if (outputList) {
+                    simplecpp::Output err(files);
+                    err.type = Output::DUI_ERROR;
+                    err.msg = "unknown standard specified: '" + dui.std + "'";
+                    outputList->push_back(err);
+                }
+                output.clear();
+                return;
+            }
+            macros.insert(std::make_pair("__cplusplus", Macro("__cplusplus", std_def, dummy)));
         }
     }
 

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -181,7 +181,8 @@ namespace simplecpp {
             PORTABILITY_BACKSLASH,
             UNHANDLED_CHAR_ERROR,
             EXPLICIT_INCLUDE_NOT_FOUND,
-            FILE_NOT_FOUND
+            FILE_NOT_FOUND,
+            DUI_ERROR
         } type;
         explicit Output(const std::vector<std::string>& files, Type type, const std::string& msg) : type(type), location(files), msg(msg) {}
         Location location;

--- a/test.cpp
+++ b/test.cpp
@@ -154,6 +154,9 @@ static std::string toString(const simplecpp::OutputList &outputList)
         case simplecpp::Output::Type::FILE_NOT_FOUND:
             ostr << "file_not_found,";
             break;
+        case simplecpp::Output::Type::DUI_ERROR:
+            ostr << "dui_error,";
+            break;
         }
 
         ostr << output.msg << '\n';
@@ -2656,6 +2659,48 @@ static void cpluscplusDefine()
     ASSERT_EQUALS("\n201103L", preprocess(code, dui));
 }
 
+static void invalidStd()
+{
+    const char code[] = "";
+    simplecpp::DUI dui;
+    simplecpp::OutputList outputList;
+
+    dui.std = "c88";
+    ASSERT_EQUALS("", preprocess(code, dui, &outputList));
+    ASSERT_EQUALS(1, outputList.size());
+    ASSERT_EQUALS(simplecpp::Output::Type::DUI_ERROR, outputList.cbegin()->type);
+    ASSERT_EQUALS("unknown standard specified: 'c88'", outputList.cbegin()->msg);
+    outputList.clear();
+
+    dui.std = "gnu88";
+    ASSERT_EQUALS("", preprocess(code, dui, &outputList));
+    ASSERT_EQUALS(1, outputList.size());
+    ASSERT_EQUALS(simplecpp::Output::Type::DUI_ERROR, outputList.cbegin()->type);
+    ASSERT_EQUALS("unknown standard specified: 'gnu88'", outputList.cbegin()->msg);
+    outputList.clear();
+
+    dui.std = "d99";
+    ASSERT_EQUALS("", preprocess(code, dui, &outputList));
+    ASSERT_EQUALS(1, outputList.size());
+    ASSERT_EQUALS(simplecpp::Output::Type::DUI_ERROR, outputList.cbegin()->type);
+    ASSERT_EQUALS("unknown standard specified: 'd99'", outputList.cbegin()->msg);
+    outputList.clear();
+
+    dui.std = "c++77";
+    ASSERT_EQUALS("", preprocess(code, dui, &outputList));
+    ASSERT_EQUALS(1, outputList.size());
+    ASSERT_EQUALS(simplecpp::Output::Type::DUI_ERROR, outputList.cbegin()->type);
+    ASSERT_EQUALS("unknown standard specified: 'c++77'", outputList.cbegin()->msg);
+    outputList.clear();
+
+    dui.std = "gnu++33";
+    ASSERT_EQUALS("", preprocess(code, dui, &outputList));
+    ASSERT_EQUALS(1, outputList.size());
+    ASSERT_EQUALS(simplecpp::Output::Type::DUI_ERROR, outputList.cbegin()->type);
+    ASSERT_EQUALS("unknown standard specified: 'gnu++33'", outputList.cbegin()->msg);
+    outputList.clear();
+}
+
 static void assertToken(const std::string& s, bool name, bool number, bool comment, char op, int line)
 {
     const std::vector<std::string> f;
@@ -2984,6 +3029,7 @@ int main(int argc, char **argv)
 
     TEST_CASE(stdcVersionDefine);
     TEST_CASE(cpluscplusDefine);
+    TEST_CASE(invalidStd);
 
     TEST_CASE(token);
 


### PR DESCRIPTION
If the value is unknown we are silently setting an invalid/unexcepted value for the predefined macros which might lead to other issues.