### PR TITLE
return proper `__cplusplus` value for C++23 / improved preliminary C23 support

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3701,7 +3701,7 @@ std::string simplecpp::getCppStdString(const std::string &std)
         // GCC 11, 12, 13 return "202100L"
         // Clang 12, 13, 14, 15, 16 do not support "c++23" and "gnu++23" and return "202101L"
         // Clang 17, 18 return "202302L"
-        return "202100L"; // TODO: update value?
+        return "202302L";
     }
     if (std == "c++26" || std == "c++2c" || std == "gnu++26" || std == "gnu++2c") {
         // supported by Clang 17+

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3674,10 +3674,12 @@ std::string simplecpp::getCStdString(const std::string &std)
         return "201112L";
     if (std == "c17" || std == "c18" || std == "iso9899:2017" || std == "iso9899:2018" || std == "gnu17"|| std == "gnu18")
         return "201710L";
-    if (std == "c2x" || std == "gnu2x") {
+    if (std == "c23" || std == "gnu23" || std == "c2x" || std == "gnu2x") {
         // supported by GCC 9+ and Clang 9+
         // Clang 9, 10, 11, 12, 13 return "201710L"
-        return "202000L";
+        // Clang 14, 15, 16, 17 return "202000L"
+        // Clang 9, 10, 11, 12, 13, 14, 15, 16, 17 do not support "c23" and "gnu23"
+        return "202311L";
     }
     return "";
 }


### PR DESCRIPTION
The value for `__cplusplus` with C++23 is documented at [https://gcc.g…](https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html) 

…nu.org/onlinedocs/cpp/Standard-Predefined-Macros.html.