### PR TITLE
avoid some redundant checks in `TokenList::readfile()`

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -625,8 +625,6 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
         unsigned char ch = stream.readChar();
         if (!stream.good())
             break;
-        if (ch < ' ' && ch != '\t' && ch != '\n' && ch != '\r')
-            ch = ' ';
 
         if (ch >= 0x80) {
             if (outputList) {
@@ -692,7 +690,7 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
             continue;
         }
 
-        if (std::isspace(ch)) {
+        if (ch <= ' ') {
             location.col++;
             continue;
         }


### PR DESCRIPTION
calling `isspace()` is unnecessary since we handle all non-ASCII characters and already have special handling of all remaining whitespaces according to https://en.cppreference.com/w/cpp/string/byte/isspace.

Runinng with `-q -D__GNUC__ -Ilib lib/valueflow.cpp`

Clang 16 `276,826,655` -> `270,642,840`
GCC 13 `283,762,095`-> `280,179,302`
