### PR TITLE
optimized `lastLine()` usage in `readfile()`

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1406,7 +1406,7 @@ const simplecpp::Token* simplecpp::TokenList::lastLineTok(int maxsize) const
 bool simplecpp::TokenList::isLastLinePreprocessor(int maxsize) const
 {
     const Token * const prevTok = lastLineTok(maxsize);
-    return prevTok && prevTok->str()[0] == '#';
+    return prevTok && prevTok->op == '#';
 }
 
 unsigned int simplecpp::TokenList::fileIndex(const std::string &filename)

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -299,7 +299,7 @@ namespace simplecpp {
         void lineDirective(unsigned int fileIndex, unsigned int line, Location *location);
 
         std::string lastLine(int maxsize=1000) const;
-        bool isLastLinePreprocessor(int maxsize=100000) const;
+        bool isLastLinePreprocessor(int maxsize=1000) const;
 
         unsigned int fileIndex(const std::string &filename);
 

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -299,6 +299,7 @@ namespace simplecpp {
         void lineDirective(unsigned int fileIndex, unsigned int line, Location *location);
 
         std::string lastLine(int maxsize=1000) const;
+        const Token* lastLineTok(int maxsize=1000) const;
         bool isLastLinePreprocessor(int maxsize=1000) const;
 
         unsigned int fileIndex(const std::string &filename);


### PR DESCRIPTION
Using the headers from https://sourceforge.net/p/cppcheck/discussion/development/thread/4e3ff7c875/:

a.h
```
Benchmark 1: ./simplecpp -q test.c
  Time (mean ± σ):       9.2 ms ±   0.6 ms    [User: 8.1 ms, System: 1.2 ms]
  Range (min … max):     8.3 ms …  11.4 ms    250 runs
```

```
Benchmark 1: ./simplecpp -q test.c
  Time (mean ± σ):       3.4 ms ±   0.5 ms    [User: 2.6 ms, System: 1.2 ms]
  Range (min … max):     2.3 ms …   5.8 ms    488 runs
```

b.h
```
Benchmark 1: ./simplecpp -q test.c
  Time (mean ± σ):     140.6 ms ±   1.7 ms    [User: 137.2 ms, System: 3.3 ms]
  Range (min … max):   137.6 ms … 143.8 ms    20 runs
```

```
Benchmark 1: ./simplecpp -q test.c
  Time (mean ± σ):      13.2 ms ±   1.4 ms    [User: 10.4 ms, System: 2.8 ms]
  Range (min … max):    11.7 ms …  19.3 ms    148 runs
```