### PR TITLE
mitigated `include-what-you-use` warnings

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -20,13 +20,13 @@
 #include <cstring>
 #include <ctime>
 #include <exception>
-#include <fstream> // IWYU pragma: keep
+#include <fstream>
 #include <iostream>
 #include <limits>
 #include <list>
 #include <map>
 #include <set>
-#include <sstream> // IWYU pragma: keep
+#include <sstream>
 #include <stack>
 #include <stdexcept>
 #include <string>

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -14,7 +14,7 @@
 #include <cassert>
 #include <cctype>
 #include <climits>
-#include <cstddef>
+#include <cstddef> // IWYU pragma: keep
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
`include-what-you-use` and `clang-include-cleaner` disagree about this. Since we have the latter enabled in this repo appease it for now by re-adding the include and suppress the IWYU warning.