### PR TITLE
refs #342 - do not load included files twice in CLI application / added `DUI::removeComment`

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 int main(int argc, char **argv)
@@ -110,6 +109,8 @@ int main(int argc, char **argv)
         std::exit(0);
     }
 
+    dui.removeComments = true;
+
     // Perform preprocessing
     simplecpp::OutputList outputList;
     std::vector<std::string> files;
@@ -126,11 +127,10 @@ int main(int argc, char **argv)
         rawtokens = new simplecpp::TokenList(filename,files,&outputList);
     }
     rawtokens->removeComments();
-    std::map<std::string, simplecpp::TokenList*> included = simplecpp::load(*rawtokens, files, dui, &outputList);
-    for (std::pair<std::string, simplecpp::TokenList *> i : included)
-        i.second->removeComments();
     simplecpp::TokenList outputTokens(files);
-    simplecpp::preprocess(outputTokens, *rawtokens, files, included, dui, &outputList);
+    std::map<std::string, simplecpp::TokenList*> filedata;
+    simplecpp::preprocess(outputTokens, *rawtokens, files, filedata, dui, &outputList);
+    simplecpp::cleanup(filedata);
     delete rawtokens;
     rawtokens = nullptr;
 
@@ -173,9 +173,6 @@ int main(int argc, char **argv)
             std::cerr << output.msg << std::endl;
         }
     }
-
-    // cleanup included tokenlists
-    simplecpp::cleanup(included);
 
     return 0;
 }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3143,6 +3143,8 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
             continue;
         }
 
+        if (dui.removeComments)
+            tokenlist->removeComments();
         ret[filename] = tokenlist;
         filelist.push_back(tokenlist->front());
     }
@@ -3178,6 +3180,8 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
         f.close();
 
         TokenList *tokens = new TokenList(header2, filenames, outputList);
+        if (dui.removeComments)
+            tokens->removeComments();
         ret[header2] = tokens;
         if (tokens->front())
             filelist.push_back(tokens->front());
@@ -3446,6 +3450,8 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
                     header2 = openHeader(f, dui, rawtok->location.file(), header, systemheader);
                     if (f.is_open()) {
                         TokenList * const tokens = new TokenList(f, files, header2, outputList);
+                        if (dui.removeComments)
+                            tokens->removeComments();
                         filedata[header2] = tokens;
                     }
                 }

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -320,13 +320,14 @@ namespace simplecpp {
      * On the command line these are configured by -D, -U, -I, --include, -std
      */
     struct SIMPLECPP_LIB DUI {
-        DUI() : clearIncludeCache(false) {}
+        DUI() : clearIncludeCache(false), removeComments(false) {}
         std::list<std::string> defines;
         std::set<std::string> undefined;
         std::list<std::string> includePaths;
         std::list<std::string> includes;
         std::string std;
         bool clearIncludeCache;
+        bool removeComments; /** remove comment tokens from included files */
     };
 
     SIMPLECPP_LIB long long characterLiteralToLL(const std::string& str);


### PR DESCRIPTION
The CLI application was pre-loading the included files just to remove the comments. Adding a `DUI` option for that makes it necessary. This makes profiling with the CLI more useful and it also fixes a potential memory leak in the CLI when an empty (or currently also non-existent) include was specified.