### PR TITLE
fixed fuzzing crash in `simplecpp::Macro::expandToken()`

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1984,7 +1984,7 @@ namespace simplecpp {
                             if (paren == 0)
                               return tok->next->next;
                             tok = tok->next;
-                            if (parametertokens.front()->next->str() != ")" && parametertokens.size() > args.size())
+                            if (parametertokens.size() > args.size() && parametertokens.front()->next->str() != ")")
                               tok = expandToken(output, loc, tok, macros, expandedmacros, parametertokens)->previous;
                         }
                     }

--- a/test.cpp
+++ b/test.cpp
@@ -2714,6 +2714,15 @@ static void token()
     ASSERT_TOKEN("+22", false, true, false);
 }
 
+static void fuzz_crash()
+{
+    {
+        const char code[] = "#define n __VA_OPT__(u\n"
+                            "n\n";
+        (void)preprocess(code, simplecpp::DUI()); // do not crash
+    }
+}
+
 int main(int argc, char **argv)
 {
     TEST_CASE(backslash);
@@ -2939,6 +2948,8 @@ int main(int argc, char **argv)
     TEST_CASE(cpluscplusDefine);
 
     TEST_CASE(token);
+
+    TEST_CASE(fuzz_crash);
 
     return numberOfFailedAssertions > 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
```
/usr/bin/../include/c++/v1/vector:570:16: runtime error: reference binding to null pointer of type 'const value_type' (aka 'const simplecpp::Token *const')
    #0 0x641340cb01e2 in front /usr/bin/../include/c++/v1/vector:570:9
    #1 0x641340cb01e2 in simplecpp::Macro::expandToken(simplecpp::TokenList*, simplecpp::Location const&, simplecpp::Token const*, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, simplecpp::Macro, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, simplecpp::Macro>>> const&, std::__1::set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, std::__1::vector<simplecpp::Token const*, std::__1::allocator<simplecpp::Token const*>> const&) const /home/user/CLionProjects/simplecpp-rider/simplecpp.cpp:1994:49
    #2 0x641340ca99ee in simplecpp::Macro::expand(simplecpp::TokenList*, simplecpp::Location const&, simplecpp::Token const*, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, simplecpp::Macro, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, simplecpp::Macro>>> const&, std::__1::set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, bool) const /home/user/CLionProjects/simplecpp-rider/simplecpp.cpp:1887:31
    #3 0x641340ca4c53 in simplecpp::Macro::expand(simplecpp::TokenList*, simplecpp::Token const*, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, simplecpp::Macro, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, simplecpp::Macro>>> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&) const /home/user/CLionProjects/simplecpp-rider/simplecpp.cpp:1529:26
    #4 0x641340c74fa5 in preprocessToken(simplecpp::TokenList&, simplecpp::Token const**, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, simplecpp::Macro, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, simplecpp::Macro>>>&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&, std::__1::list<simplecpp::Output, std::__1::allocator<simplecpp::Output>>*) /home/user/CLionProjects/simplecpp-rider/simplecpp.cpp:3210:32
    #5 0x641340c60ba7 in simplecpp::preprocess(simplecpp::TokenList&, simplecpp::TokenList const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&, std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, simplecpp::TokenList*, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, simplecpp::TokenList*>>>&, simplecpp::DUI const&, std::__1::list<simplecpp::Output, std::__1::allocator<simplecpp::Output>>*, std::__1::list<simplecpp::MacroUsage, std::__1::allocator<simplecpp::MacroUsage>>*, std::__1::list<simplecpp::IfCond, std::__1::allocator<simplecpp::IfCond>>*) /home/user/CLionProjects/simplecpp-rider/simplecpp.cpp:3681:14
    #6 0x641340cece61 in LLVMFuzzerTestOneInput /home/user/CLionProjects/simplecpp-rider/fuzz.cpp:31:5
    #7 0x641340ad3168 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/user/CLionProjects/simplecpp-rider/fuzz+0xd3168) (BuildId: c67f7ae0ae4f90bce06e963fc0d95c2c7f3417a7)
    #8 0x641340ad3866 in fuzzer::Fuzzer::MinimizeCrashLoop(std::vector<unsigned char, std::allocator<unsigned char>> const&) (/home/user/CLionProjects/simplecpp-rider/fuzz+0xd3866) (BuildId: c67f7ae0ae4f90bce06e963fc0d95c2c7f3417a7)
    #9 0x641340aa9a8b in fuzzer::MinimizeCrashInputInternalStep(fuzzer::Fuzzer*, fuzzer::InputCorpus*) (/home/user/CLionProjects/simplecpp-rider/fuzz+0xa9a8b) (BuildId: c67f7ae0ae4f90bce06e963fc0d95c2c7f3417a7)
    #10 0x641340ab6198 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/user/CLionProjects/simplecpp-rider/fuzz+0xb6198) (BuildId: c67f7ae0ae4f90bce06e963fc0d95c2c7f3417a7)
    #11 0x641340a9d947 in main (/home/user/CLionProjects/simplecpp-rider/fuzz+0x9d947) (BuildId: c67f7ae0ae4f90bce06e963fc0d95c2c7f3417a7)
    #12 0x7e81557e7ccf  (/usr/lib/libc.so.6+0x29ccf) (BuildId: 0865c4b9ba13e0094e8b45b78dfc7a2971f536d2)
    #13 0x7e81557e7d89 in __libc_start_main (/usr/lib/libc.so.6+0x29d89) (BuildId: 0865c4b9ba13e0094e8b45b78dfc7a2971f536d2)
    #14 0x641340a9ff84 in _start (/home/user/CLionProjects/simplecpp-rider/fuzz+0x9ff84) (BuildId: c67f7ae0ae4f90bce06e963fc0d95c2c7f3417a7)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/bin/../include/c++/v1/vector:570:16 in
```