### PR TITLE
CI-unixish.yml: removed `macos-11` / added `macos-13` and `macos-14`

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         compiler: [clang++, g++]
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, macos-14]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
`macos-11` is no longer available