### PR TITLE
fix: use both absolute and relative header paths in header matching

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -38,8 +38,8 @@ jobs:
 
     - name: Install missing Python packages
       run: |
-        python3 -m pip --user install pip --upgrade
-        python3 -m pip --user install pytest
+        python3 -m pip install pip --upgrade --user
+        python3 -m pip install pytest --user
 
     - name: make simplecpp
       run: make -j$(nproc)

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -38,8 +38,8 @@ jobs:
 
     - name: Install missing Python packages
       run: |
-        python3 -m pip install pip --upgrade
-        python3 -m pip install pytest
+        python3 -m pip --user install pip --upgrade
+        python3 -m pip --user install pytest
 
     - name: make simplecpp
       run: make -j$(nproc)

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -38,8 +38,8 @@ jobs:
 
     - name: Install missing Python packages
       run: |
-        python3 -m pip install pip --upgrade --user
-        python3 -m pip install pytest --user
+        python3 -m pip install --break-system-packages pip --upgrade
+        python3 -m pip install --break-system-packages pytest
 
     - name: make simplecpp
       run: make -j$(nproc)

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -38,8 +38,9 @@ jobs:
 
     - name: Install missing Python packages
       run: |
-        python3 -m pip install --break-system-packages pip --upgrade
-        python3 -m pip install --break-system-packages pytest
+        python3 -m pip config set global.break-system-packages true
+        python3 -m pip install pip --upgrade
+        python3 -m pip install pytest
 
     - name: make simplecpp
       run: make -j$(nproc)

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -30,7 +30,17 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libc++-18-dev
-          
+
+    - name: Install missing software on macos
+      if: contains(matrix.os, 'macos')
+      run: |
+        brew install python3
+
+    - name: Install missing Python packages
+      run: |
+        python3 -m pip install pip --upgrade
+        python3 -m pip install pytest
+
     - name: make simplecpp
       run: make -j$(nproc)
 
@@ -40,6 +50,10 @@ jobs:
     - name: selfcheck
       run: |
         make -j$(nproc) selfcheck
+
+    - name: integration test
+      run: |
+        python3 -m pytest integration_test.py
 
     - name: Run CMake
       run: |

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -26,7 +26,18 @@ jobs:
 
       - name: Setup msbuild.exe
         uses: microsoft/setup-msbuild@v2
-        
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          check-latest: true
+
+      - name: Install missing Python packages
+        run: |
+          python -m pip install pip --upgrade || exit /b !errorlevel!
+          python -m pip install pytest || exit /b !errorlevel!
+
       - name: Run cmake
         if: matrix.os == 'windows-2019'
         run: |
@@ -48,4 +59,8 @@ jobs:
       - name: Selfcheck
         run: |
           .\${{ matrix.config }}\simplecpp.exe simplecpp.cpp -e || exit /b !errorlevel!
+
+      - name: integration test
+        run: |
+          python -m pytest integration_test.py || exit /b !errorlevel!
         

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -62,6 +62,6 @@ jobs:
 
       - name: integration test
         run: |
-          set SIMPLECPP_EXE_PATH=".\${{ matrix.config }}\simplecpp.exe"
+          set SIMPLECPP_EXE_PATH=.\${{ matrix.config }}\simplecpp.exe
           python -m pytest integration_test.py || exit /b !errorlevel!
         

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -62,5 +62,6 @@ jobs:
 
       - name: integration test
         run: |
+          set SIMPLECPP_EXE_PATH=".\${{ matrix.config }}\simplecpp.exe"
           python -m pytest integration_test.py || exit /b !errorlevel!
         

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ testrunner
 # CLion
 /.idea
 /cmake-build-*
+
+# python
+__pycache__/

--- a/integration_test.py
+++ b/integration_test.py
@@ -1,0 +1,131 @@
+## test with python -m pytest integration_test.py
+
+import os
+from testutils import simplecpp, format_include_path_arg, format_include
+
+def __test_relative_header_create_header(dir, with_pragma_once=True):
+    header_file = os.path.join(dir, 'test.h')
+    with open(header_file, 'wt') as f:
+        f.write(f"""
+                {"#pragma once" if with_pragma_once else ""}
+                #ifndef TEST_H_INCLUDED
+                #define TEST_H_INCLUDED
+                #else
+                #error header_was_already_included
+                #endif
+                """)
+    return header_file, "error: #error header_was_already_included"
+
+def __test_relative_header_create_source(dir, include1, include2, is_include1_sys=False, is_include2_sys=False):
+    src_file = os.path.join(dir, 'test.c')
+    with open(src_file, 'wt') as f:
+        f.write(f"""
+                #undef TEST_H_INCLUDED
+                #include {format_include(include1, is_include1_sys)}
+                #include {format_include(include2, is_include2_sys)}
+                """)
+    return src_file
+
+
+def test_relative_header_0_rel(tmpdir):
+    _, double_include_error = __test_relative_header_create_header(tmpdir, with_pragma_once=False)
+
+    test_file = __test_relative_header_create_source(tmpdir, "test.h", "test.h")
+
+    args = [test_file]
+
+    _, _, stderr = simplecpp(args, cwd=tmpdir)
+    assert double_include_error in stderr
+
+def test_relative_header_0_sys(tmpdir):
+    _, double_include_error = __test_relative_header_create_header(tmpdir, with_pragma_once=False)
+
+    test_file = __test_relative_header_create_source(tmpdir, "test.h", "test.h", is_include1_sys=True, is_include2_sys=True)
+
+    args = [format_include_path_arg(tmpdir), test_file]
+
+    _, _, stderr = simplecpp(args)
+    assert double_include_error in stderr
+
+def test_relative_header_1_rel(tmpdir):
+    __test_relative_header_create_header(tmpdir)
+
+    test_file = __test_relative_header_create_source(tmpdir, "test.h", "test.h")
+
+    args = [test_file]
+
+    _, _, stderr = simplecpp(args, cwd=tmpdir)
+    assert stderr == ''
+
+def test_relative_header_1_sys(tmpdir):
+    __test_relative_header_create_header(tmpdir)
+
+    test_file = __test_relative_header_create_source(tmpdir, "test.h", "test.h", is_include1_sys=True, is_include2_sys=True)
+
+    args = [format_include_path_arg(tmpdir), test_file]
+
+    _, _, stderr = simplecpp(args)
+    assert stderr == ''
+
+## TODO: the following tests should pass after applying simplecpp#362
+
+def test_relative_header_2(tmpdir):
+    header_file, _ = __test_relative_header_create_header(tmpdir)
+
+    test_file = __test_relative_header_create_source(tmpdir, "test.h", header_file)
+
+    args = [test_file]
+
+    _, _, stderr = simplecpp(args, cwd=tmpdir)
+    assert stderr == ''
+
+def test_relative_header_3(tmpdir):
+    test_subdir = os.path.join(tmpdir, "test_subdir")
+    os.mkdir(test_subdir)
+    header_file, _ = __test_relative_header_create_header(test_subdir)
+
+    test_file = __test_relative_header_create_source(tmpdir, "test_subdir/test.h", header_file)
+
+    args = [test_file]
+
+    _, _, stderr = simplecpp(args, cwd=tmpdir)
+    assert stderr == ''
+
+def test_relative_header_3_inv(tmpdir):
+    test_subdir = os.path.join(tmpdir, "test_subdir")
+    os.mkdir(test_subdir)
+    header_file, _ = __test_relative_header_create_header(test_subdir)
+
+    test_file = __test_relative_header_create_source(tmpdir, header_file, "test_subdir/test.h")
+
+    args = [test_file]
+
+    _, _, stderr = simplecpp(args, cwd=tmpdir)
+    assert stderr == ''
+
+
+def test_relative_header_4(tmpdir):
+    test_subdir = os.path.join(tmpdir, "test_subdir")
+    os.mkdir(test_subdir)
+    header_file, _ = __test_relative_header_create_header(test_subdir)
+
+    test_file = __test_relative_header_create_source(tmpdir, header_file, "test.h", is_include2_sys=True)
+
+    args = [format_include_path_arg(test_subdir), test_file]
+
+    _, _, stderr = simplecpp(args, cwd=tmpdir)
+    assert stderr == ''
+
+
+
+def test_relative_header_5(tmpdir):
+    test_subdir = os.path.join(tmpdir, "test_subdir")
+    os.mkdir(test_subdir)
+    __test_relative_header_create_header(test_subdir)
+
+    test_file = __test_relative_header_create_source(tmpdir, "test.h", "test_subdir/test.h", is_include1_sys=True)
+
+    args = [format_include_path_arg(test_subdir), test_file]
+
+    _, _, stderr = simplecpp(args, cwd=tmpdir)
+    assert stderr == ''

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2680,7 +2680,7 @@ static std::string currentDirectoryOSCalc() {
 }
 
 static const std::string& currentDirectory() {
-    static std::string curdir = simplecpp::simplifyPath(currentDirectoryOSCalc());
+    static const std::string curdir = simplecpp::simplifyPath(currentDirectoryOSCalc());
     return curdir;
 }
 
@@ -2698,7 +2698,7 @@ static std::string toAbsolutePath(const std::string& path) {
 static std::pair<std::string, bool> extractRelativePathFromAbsolute(const std::string& absolutepath) {
     static const std::string prefix = currentDirectory() + "/";
     if (startsWith(absolutepath, prefix)) {
-        std::size_t size = prefix.size();
+        const std::size_t size = prefix.size();
         return std::make_pair(absolutepath.substr(size, absolutepath.size() - size), true);
     }
     // otherwise
@@ -3215,8 +3215,7 @@ static std::string getFileIdPath(const std::map<std::string, simplecpp::TokenLis
     }
 
     for (std::list<std::string>::const_iterator it = dui.includePaths.begin(); it != dui.includePaths.end(); ++it) {
-        std::string s = simplecpp::simplifyPath(getIncludePathFileName(*it, header));
-        const std::string match = findPathInMapBothRelativeAndAbsolute(filedata, s);
+        const std::string match = findPathInMapBothRelativeAndAbsolute(filedata, simplecpp::simplifyPath(getIncludePathFileName(*it, header)));
         if (!match.empty()) {
             return match;
         }

--- a/testutils.py
+++ b/testutils.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import json
+
+def __run_subprocess(args, env=None, cwd=None, timeout=None):
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, cwd=cwd)
+
+    try:
+        stdout, stderr = p.communicate(timeout=timeout)
+        return_code = p.returncode
+        p = None
+    except subprocess.TimeoutExpired:
+        import psutil
+        # terminate all the child processes
+        child_procs = psutil.Process(p.pid).children(recursive=True)
+        if len(child_procs) > 0:
+            for child in child_procs:
+                child.terminate()
+            try:
+                # call with timeout since it might be stuck
+                p.communicate(timeout=5)
+                p = None
+            except subprocess.TimeoutExpired:
+                pass
+        raise
+    finally:
+        if p:
+            # sending the signal to the process groups causes the parent Python process to terminate as well
+            #os.killpg(os.getpgid(p.pid), signal.SIGTERM)  # Send the signal to all the process groups
+            p.terminate()
+            stdout, stderr = p.communicate()
+            p = None
+
+    stdout = stdout.decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')
+    stderr = stderr.decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')
+
+    return return_code, stdout, stderr
+
+def simplecpp(args = [], cwd = None):
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    simplecpp_path = os.path.join(dir_path, "simplecpp")
+    return __run_subprocess([simplecpp_path] + args, cwd = cwd)
+
+def quoted_string(s):
+    return json.dumps(str(s))
+
+def format_include_path_arg(include_path):
+    return f"-I{str(include_path)}"
+
+def format_include(include, is_sys_header=False):
+    if is_sys_header:
+        return f"<{quoted_string(include)[1:-1]}>"
+    else:
+        return quoted_string(include)

--- a/testutils.py
+++ b/testutils.py
@@ -38,7 +38,10 @@ def __run_subprocess(args, env=None, cwd=None, timeout=None):
 
 def simplecpp(args = [], cwd = None):
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    simplecpp_path = os.path.join(dir_path, "simplecpp")
+    if 'SIMPLECPP_EXE_PATH' in os.environ:
+        simplecpp_path = os.environ['SIMPLECPP_EXE_PATH']
+    else:
+        simplecpp_path = os.path.join(dir_path, "simplecpp")
     return __run_subprocess([simplecpp_path] + args, cwd = cwd)
 
 def quoted_string(s):


### PR DESCRIPTION
Fixes #402

This fix an issue of importing the same header by different addresses.
The issue is trickier than seems, because if a user used the include dir flag `-I...` with an absolute path, then every matched header was detected to be absolute, but if the import was a relative import to the source file and the source file isn't with an absolute path, than the header is identified by the combined relative path.

See https://sourceforge.net/p/cppcheck/discussion/general/thread/c01f80556b/

Note - I tried to make the code compatible with Windows, but was tested only on linux.