### PR TITLE
#pragma once usage to prevent unwanted inclusions from happening even once

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2178,7 +2178,7 @@ namespace simplecpp {
             if (!sameline(tok, tok->next) || !sameline(tok, tok->next->next))
                 throw invalidHashHash::unexpectedNewline(tok->location, name());
 
-            const bool canBeConcatenatedWithEqual = A->isOneOf("+-*/%&|^") || A->str() == "<<" || A->str() == ">>";
+            const bool canBeConcatenatedWithEqual = A->isOneOf("+-*/%&|^=!<>") || A->str() == "<<" || A->str() == ">>";
             const bool canBeConcatenatedStringOrChar = isStringLiteral_(A->str()) || isCharLiteral_(A->str());
             if (!A->name && !A->number && A->op != ',' && !A->str().empty() && !canBeConcatenatedWithEqual && !canBeConcatenatedStringOrChar)
                 throw invalidHashHash::unexpectedToken(tok->location, name(), A);

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -47,6 +47,7 @@ namespace simplecpp {
 
     typedef std::string TokenString;
     class Macro;
+    class Mask;
 
     /**
      * Location in source code

--- a/test.cpp
+++ b/test.cpp
@@ -1155,6 +1155,10 @@ static void hashhash9()
                         "ADD_OPERATOR(&);\n"
                         "ADD_OPERATOR(|);\n"
                         "ADD_OPERATOR(^);\n"
+                        "ADD_OPERATOR(=);\n"
+                        "ADD_OPERATOR(!);\n"
+                        "ADD_OPERATOR(<);\n"
+                        "ADD_OPERATOR(>);\n"
                         "ADD_OPERATOR(<<);\n"
                         "ADD_OPERATOR(>>);\n";
     const char expected[] = "\n"
@@ -1166,6 +1170,10 @@ static void hashhash9()
                             "void operator &= ( void ) { x = x & 1 ; } ;\n"
                             "void operator |= ( void ) { x = x | 1 ; } ;\n"
                             "void operator ^= ( void ) { x = x ^ 1 ; } ;\n"
+                            "void operator == ( void ) { x = x = 1 ; } ;\n"
+                            "void operator != ( void ) { x = x ! 1 ; } ;\n"
+                            "void operator <= ( void ) { x = x < 1 ; } ;\n"
+                            "void operator >= ( void ) { x = x > 1 ; } ;\n"
                             "void operator <<= ( void ) { x = x << 1 ; } ;\n"
                             "void operator >>= ( void ) { x = x >> 1 ; } ;";
     ASSERT_EQUALS(expected, preprocess(code));
@@ -1374,7 +1382,7 @@ static void hashhash_invalid_string_number()
         "#define BAD(x) x##12345\nBAD(\"ABC\")";
 
     simplecpp::OutputList outputList;
-    preprocess(code, simplecpp::DUI(), &outputList);
+    preprocess(code, &outputList);
     ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'BAD', Invalid ## usage when expanding 'BAD': Combining '\"ABC\"' and '12345' yields an invalid token.\n", toString(outputList));
 }
 
@@ -1384,7 +1392,7 @@ static void hashhash_invalid_missing_args()
         "#define BAD(x) ##x\nBAD()";
 
     simplecpp::OutputList outputList;
-    preprocess(code, simplecpp::DUI(), &outputList);
+    preprocess(code, &outputList);
     ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'BAD', Invalid ## usage when expanding 'BAD': Missing first argument\n", toString(outputList));
 }
 
@@ -1405,7 +1413,7 @@ static void hashhash_universal_character()
     const char code[] =
         "#define A(x,y) x##y\nint A(\\u01,04);";
     simplecpp::OutputList outputList;
-    preprocess(code, simplecpp::DUI(), &outputList);
+    preprocess(code, &outputList);
     ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'A', Invalid ## usage when expanding 'A': Combining '\\u01' and '04' yields universal character '\\u0104'. This is undefined behavior according to C standard chapter 5.1.1.2, paragraph 4.\n", toString(outputList));
 }
 
@@ -2915,7 +2923,7 @@ static void fuzz_crash()
     {
         const char code[] = "#define n __VA_OPT__(u\n"
                             "n\n";
-        (void)preprocess(code, simplecpp::DUI()); // do not crash
+        (void)preprocess(code); // do not crash
     }
 }
 

--- a/test.cpp
+++ b/test.cpp
@@ -18,6 +18,7 @@
 
 #define STRINGIZE_(x) #x
 #define STRINGIZE(x) STRINGIZE_(x)
+#define CODE(x) #x "\n"
 
 static int numberOfFailedAssertions = 0;
 
@@ -1839,18 +1840,17 @@ static void missingHeader3()
 
 static void missingHeader4()
 {
-    const char code[] = R"_(
-        #pragma once "^boost/"
-        #pragma once "^google/protobuf/"
-        #pragma once "\.pb\.h$"
-        #pragma once "^inc/"i
-        #include "boost/config/workaround.hpp"
-        #include "google/protobuf/stubs/port.h"
-        #include "proto/message.pb.h"
-        #include "inc/lowercase.h"
-        #include "Inc/MixedCase.h"
-        #include "INC/UPPERCASE.H"
-    )_"; // none of the given files are included
+    const char code[] = CODE(#pragma once "boost/*")
+                        CODE(#pragma once "google/protobuf/*")
+                        CODE(#pragma once "*.pb.h")
+                        CODE(#pragma once "inc/*" i)
+                        CODE(#include "boost/config/workaround.hpp")
+                        CODE(#include "google/protobuf/stubs/port.h")
+                        CODE(#include "proto/message.pb.h")
+                        CODE(#include "inc/lowercase.h")
+                        CODE(#include "Inc/MixedCase.h")
+                        CODE(#include "INC/UPPERCASE.H");
+    // none of the given files are included
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code, &outputList));
     ASSERT_EQUALS("", toString(outputList));

--- a/test.cpp
+++ b/test.cpp
@@ -1829,6 +1829,25 @@ static void missingHeader3()
     ASSERT_EQUALS("", toString(outputList));
 }
 
+static void missingHeader4()
+{
+    const char code[] = R"_(
+        #pragma once "^boost/"
+        #pragma once "^google/protobuf/"
+        #pragma once "\.pb\.h$"
+        #pragma once "^inc/"i
+        #include "boost/config/workaround.hpp"
+        #include "google/protobuf/stubs/port.h"
+        #include "proto/message.pb.h"
+        #include "inc/lowercase.h"
+        #include "Inc/MixedCase.h"
+        #include "INC/UPPERCASE.H"
+    )_"; // none of the given files are included
+    simplecpp::OutputList outputList;
+    ASSERT_EQUALS("", preprocess(code, &outputList));
+    ASSERT_EQUALS("", toString(outputList));
+}
+
 static void nestedInclude()
 {
     const char code[] = "#include \"test.h\"\n";
@@ -3057,6 +3076,7 @@ int main(int argc, char **argv)
     TEST_CASE(missingHeader1);
     TEST_CASE(missingHeader2);
     TEST_CASE(missingHeader3);
+    TEST_CASE(missingHeader4);
     TEST_CASE(nestedInclude);
     TEST_CASE(systemInclude);
 


### PR DESCRIPTION
This implements the idea behind https://github.com/danmar/simplecpp/issues/159#issuecomment-506986341 in a generic way.
It works by allowing #pragma once to take a wildcard expression to sort out the unwanted include files.

Example from some project of mine, to prevent some inclusions which would otherwise cause cppcheck to abort prematurely:
```C++
#ifdef CPPCHECK
#   pragma once "boost/*"
#   pragma once "google/protobuf/*"
#   pragma once "*.pb.h"
#endif
```
Going with Cppcheck's --include option is particularly convenient for the purpose.