### PR TITLE
Allow reexpansion of currently expanding macros during argument evaluation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ option(DISABLE_CPP03_SYNTAX_CHECK "Disable the C++03 syntax check." OFF)
 
 include(CheckCXXCompilerFlag)
 
+if (WIN32)
+    # prevent simplifyPath_cppcheck() from wasting time on looking for a hypothetical network host
+    add_definitions(-DUNCHOST=$ENV{COMPUTERNAME})
+endif()
+
 function(add_compile_options_safe FLAG)
     string(MAKE_C_IDENTIFIER "HAS_CXX_FLAG${FLAG}" mangled_flag)
     check_cxx_compiler_flag(${FLAG} ${mangled_flag})

--- a/run-tests.py
+++ b/run-tests.py
@@ -71,7 +71,6 @@ todo = [
          'c99-6_10_3_4_p6.c',
          'expr_usual_conversions.c', # condition is true: 4U - 30 >= 0
          'stdint.c',
-         'stringize_misc.c',
 
          # GCC..
          'diagnostic-pragma-1.c',

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2140,7 +2140,8 @@ namespace simplecpp {
          */
         const Token *expandHash(TokenList *output, const Location &loc, const Token *tok, const MacroMap &macros, const std::set<TokenString> &expandedmacros, const std::vector<const Token*> &parametertokens) const {
             TokenList tokenListHash(files);
-            tok = expandToken(&tokenListHash, loc, tok->next, macros, expandedmacros, parametertokens);
+            const MacroMap macros2; // temporarily bypass macro expansion
+            tok = expandToken(&tokenListHash, loc, tok->next, macros2, expandedmacros, parametertokens);
             std::ostringstream ostr;
             ostr << '\"';
             for (const Token *hashtok = tokenListHash.cfront(); hashtok; hashtok = hashtok->next)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1895,6 +1895,14 @@ namespace simplecpp {
                     if (sameline(tok, tok->next) && tok->next && tok->next->op == '#' && tok->next->next && tok->next->next->op == '#') {
                         if (!sameline(tok, tok->next->next->next))
                             throw invalidHashHash::unexpectedNewline(tok->location, name());
+                        if (variadic && tok->op == ',' && tok->next->next->next->str() == args.back()) {
+                            Token *const comma = newMacroToken(tok->str(), loc, isReplaced(expandedmacros), tok);
+                            output->push_back(comma);
+                            tok = expandToken(output, loc, tok->next->next->next, macros, expandedmacros, parametertokens2);
+                            if (output->back() == comma)
+                                output->deleteToken(comma);
+                            continue;
+                        }
                         TokenList new_output(files);
                         if (!expandArg(&new_output, tok, parametertokens2))
                             output->push_back(newMacroToken(tok->str(), loc, isReplaced(expandedmacros), tok));

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2117,8 +2117,8 @@ namespace simplecpp {
             for (const Token *partok = parametertokens[argnr]->next; partok != parametertokens[argnr + 1U];) {
                 const MacroMap::const_iterator it = macros.find(partok->str());
                 if (it != macros.end() && !partok->isExpandedFrom(&it->second) && (partok->str() == name() || expandedmacros.find(partok->str()) == expandedmacros.end())) {
-                    std::set<TokenString> expandedmacros; // temporary amnesia to allow reexpansion of currently expanding macros during argument evaluation
-                    partok = it->second.expand(output, loc, partok, macros, expandedmacros);
+                    const std::set<TokenString> expandedmacros2; // temporary amnesia to allow reexpansion of currently expanding macros during argument evaluation
+                    partok = it->second.expand(output, loc, partok, macros, expandedmacros2);
                 } else {
                     output->push_back(newMacroToken(partok->str(), loc, isReplaced(expandedmacros), partok));
                     output->back()->macro = partok->macro;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2146,7 +2146,7 @@ namespace simplecpp {
          * @param parametertokens  parameters given when expanding this macro
          * @return token after the X
          */
-        const Token *expandHash(TokenList *output, const Location &loc, const Token *tok, const MacroMap &macros, const std::set<TokenString> &expandedmacros, const std::vector<const Token*> &parametertokens) const {
+        const Token *expandHash(TokenList *output, const Location &loc, const Token *tok, const MacroMap &, const std::set<TokenString> &expandedmacros, const std::vector<const Token*> &parametertokens) const {
             TokenList tokenListHash(files);
             const MacroMap macros2; // temporarily bypass macro expansion
             tok = expandToken(&tokenListHash, loc, tok->next, macros2, expandedmacros, parametertokens);

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1786,7 +1786,7 @@ namespace simplecpp {
                     // A##B => AB
                     tok = expandHashHash(tokens, rawloc, tok, macros, expandedmacros, parametertokens);
                 } else if (tok->op == '#' && sameline(tok, tok->next) && tok->next->op != '#') {
-                    tok = expandHash(tokens, rawloc, tok, macros, expandedmacros, parametertokens);
+                    tok = expandHash(tokens, rawloc, tok, expandedmacros, parametertokens);
                 } else {
                     if (!expandArg(tokens, tok, rawloc, macros, expandedmacros, parametertokens)) {
                         tokens->push_back(new Token(*tok));
@@ -1947,7 +1947,7 @@ namespace simplecpp {
                     tok = expandHashHash(output, loc, tok->previous, macros, expandedmacros, parametertokens2);
                 } else {
                     // #123 => "123"
-                    tok = expandHash(output, loc, tok->previous, macros, expandedmacros, parametertokens2);
+                    tok = expandHash(output, loc, tok->previous, expandedmacros, parametertokens2);
                 }
             }
 
@@ -2141,12 +2141,11 @@ namespace simplecpp {
          * @param output  destination tokenlist
          * @param loc     location for expanded token
          * @param tok     The # token
-         * @param macros  all macros
          * @param expandedmacros   set with expanded macros, with this macro
          * @param parametertokens  parameters given when expanding this macro
          * @return token after the X
          */
-        const Token *expandHash(TokenList *output, const Location &loc, const Token *tok, const MacroMap &, const std::set<TokenString> &expandedmacros, const std::vector<const Token*> &parametertokens) const {
+        const Token *expandHash(TokenList *output, const Location &loc, const Token *tok, const std::set<TokenString> &expandedmacros, const std::vector<const Token*> &parametertokens) const {
             TokenList tokenListHash(files);
             const MacroMap macros2; // temporarily bypass macro expansion
             tok = expandToken(&tokenListHash, loc, tok->next, macros2, expandedmacros, parametertokens);

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1561,10 +1561,7 @@ namespace simplecpp {
                     rawtokens2.push_back(new Token(rawtok->str(), rawtok1->location));
                     rawtok = rawtok->next;
                 }
-                bool first = true;
-                if (valueToken && valueToken->str() == rawtok1->str())
-                    first = false;
-                if (expand(&output2, rawtok1->location, rawtokens2.cfront(), macros, expandedmacros, first))
+                if (expand(&output2, rawtok1->location, rawtokens2.cfront(), macros, expandedmacros))
                     rawtok = rawtok1->next;
             } else {
                 rawtok = expand(&output2, rawtok->location, rawtok, macros, expandedmacros);
@@ -1809,10 +1806,8 @@ namespace simplecpp {
             return sameline(lpar,tok) ? tok : nullptr;
         }
 
-        const Token * expand(TokenList * const output, const Location &loc, const Token * const nameTokInst, const MacroMap &macros, std::set<TokenString> expandedmacros, bool first=false) const {
-
-            if (!first)
-                expandedmacros.insert(nameTokInst->str());
+        const Token * expand(TokenList * const output, const Location &loc, const Token * const nameTokInst, const MacroMap &macros, std::set<TokenString> expandedmacros) const {
+            expandedmacros.insert(nameTokInst->str());
 
             usageList.push_back(loc);
 

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -94,13 +94,13 @@ namespace simplecpp {
      */
     class SIMPLECPP_LIB Token {
     public:
-        Token(const TokenString &s, const Location &loc) :
-            location(loc), previous(nullptr), next(nullptr), string(s) {
+        Token(const TokenString &s, const Location &loc, bool wsahead = false) :
+            whitespaceahead(wsahead), location(loc), previous(nullptr), next(nullptr), string(s) {
             flags();
         }
 
         Token(const Token &tok) :
-            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), location(tok.location), previous(nullptr), next(nullptr), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {
+            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), whitespaceahead(tok.whitespaceahead), location(tok.location), previous(nullptr), next(nullptr), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {
         }
 
         void flags() {
@@ -132,6 +132,7 @@ namespace simplecpp {
         bool comment;
         bool name;
         bool number;
+        bool whitespaceahead;
         Location location;
         Token *previous;
         Token *next;
@@ -153,6 +154,8 @@ namespace simplecpp {
         void setExpandedFrom(const Token *tok, const Macro* m) {
             mExpandedFrom = tok->mExpandedFrom;
             mExpandedFrom.insert(m);
+            if (tok->whitespaceahead)
+                whitespaceahead = true;
         }
         bool isExpandedFrom(const Macro* m) const {
             return mExpandedFrom.find(m) != mExpandedFrom.end();

--- a/test.cpp
+++ b/test.cpp
@@ -1074,6 +1074,16 @@ static void hashhash4()    // nonstandard gcc/clang extension for empty varargs
     ASSERT_EQUALS("\n\na ( 1 ) ;", preprocess(code));
 }
 
+static void hashhash4a()
+{
+    const char code[] = "#define GETMYID(a) ((a))+1\n"
+                        "#define FIGHT_FOO(c, ...) foo(c, ##__VA_ARGS__)\n"
+                        "#define FIGHT_BAR(c, args...) bar(c, ##args)\n"
+                        "FIGHT_FOO(1, GETMYID(a));\n"
+                        "FIGHT_BAR(1, GETMYID(b));";
+    ASSERT_EQUALS("\n\n\nfoo ( 1 , ( ( a ) ) + 1 ) ;\nbar ( 1 , ( ( b ) ) + 1 ) ;", preprocess(code));
+}
+
 static void hashhash5()
 {
     ASSERT_EQUALS("x1", preprocess("x##__LINE__"));
@@ -2909,6 +2919,7 @@ int main(int argc, char **argv)
     TEST_CASE(hashhash2);
     TEST_CASE(hashhash3);
     TEST_CASE(hashhash4);
+    TEST_CASE(hashhash4a); // #66, #130
     TEST_CASE(hashhash5);
     TEST_CASE(hashhash6);
     TEST_CASE(hashhash7); // # ## #  (C standard; 6.10.3.3.p4)

--- a/test.cpp
+++ b/test.cpp
@@ -47,7 +47,7 @@ static int assertEquals(const std::string &expected, const std::string &actual, 
     return (expected == actual);
 }
 
-static int assertEquals(const unsigned int &expected, const unsigned int &actual, int line)
+static int assertEquals(const long long &expected, const long long &actual, int line)
 {
     return assertEquals(std::to_string(expected), std::to_string(actual), line);
 }
@@ -1038,6 +1038,12 @@ static void hash()
                   preprocess("#define bar(x) x % 2\n"
                              "#define foo(x) printf(#x \"\\n\")\n"
                              "foo(bar(3));"));
+
+    ASSERT_EQUALS("\n\n\n\"Y Y\"",
+                  preprocess("#define X(x,y)    x y\n"
+                             "#define STR_(x)   #x\n"
+                             "#define STR(x)    STR_(x)\n"
+                             "STR(X(Y,Y))"));
 }
 
 static void hashhash1()   // #4703

--- a/test.cpp
+++ b/test.cpp
@@ -16,6 +16,9 @@
 #include <string>
 #include <vector>
 
+#define STRINGIZE_(x) #x
+#define STRINGIZE(x) STRINGIZE_(x)
+
 static int numberOfFailedAssertions = 0;
 
 #define ASSERT_EQUALS(expected, actual)  (assertEquals((expected), (actual), __LINE__))
@@ -2593,8 +2596,8 @@ static void simplifyPath_cppcheck()
     ASSERT_EQUALS("src/", simplecpp::simplifyPath("src/abc/../"));
 
     // Handling of UNC paths on Windows
-    ASSERT_EQUALS("//src/test.cpp", simplecpp::simplifyPath("//src/test.cpp"));
-    ASSERT_EQUALS("//src/test.cpp", simplecpp::simplifyPath("///src/test.cpp"));
+    ASSERT_EQUALS("//" STRINGIZE(UNCHOST) "/test.cpp", simplecpp::simplifyPath("//" STRINGIZE(UNCHOST) "/test.cpp"));
+    ASSERT_EQUALS("//" STRINGIZE(UNCHOST) "/test.cpp", simplecpp::simplifyPath("///" STRINGIZE(UNCHOST) "/test.cpp"));
 }
 
 static void simplifyPath_New()

--- a/test.cpp
+++ b/test.cpp
@@ -1030,6 +1030,11 @@ static void hash()
                   preprocess("#define A(x)  (x)\n"
                              "#define B(x)  A(#x)\n"
                              "B(123)"));
+
+    ASSERT_EQUALS("\n\nprintf ( \"bar(3)\" \"\\n\" ) ;",
+                  preprocess("#define bar(x) x % 2\n"
+                             "#define foo(x) printf(#x \"\\n\")\n"
+                             "foo(bar(3));"));
 }
 
 static void hashhash1()   // #4703

--- a/test.cpp
+++ b/test.cpp
@@ -717,6 +717,17 @@ static void define_define_11()
     ASSERT_EQUALS("\n\n\n\nP2DIR ;", preprocess(code));
 }
 
+static void define_define_11a()
+{
+    const char code[] = "#define A_B_C              0x1\n"
+                        "#define A_ADDRESS          0x00001000U\n"
+                        "#define A                  ((uint32_t ) A_ADDRESS)\n"
+                        "#define CONCAT(x, y, z)    x ## _ ## y ## _ ## z\n"
+                        "#define TEST_MACRO         CONCAT(A, B, C)\n"
+                        "TEST_MACRO\n";
+    ASSERT_EQUALS("\n\n\n\n\n0x1", preprocess(code));
+}
+
 static void define_define_12()
 {
     const char code[] = "#define XY(Z)  Z\n"
@@ -2855,6 +2866,7 @@ int main(int argc, char **argv)
     TEST_CASE(define_define_9); // line break in nested macro call
     TEST_CASE(define_define_10);
     TEST_CASE(define_define_11);
+    TEST_CASE(define_define_11a);
     TEST_CASE(define_define_12); // expand result of ##
     TEST_CASE(define_define_13);
     TEST_CASE(define_define_14);


### PR DESCRIPTION
This fixes #31 as reproduced in TEST_CASE(define_define_11) without breaking code from @ydamigos's comment to #225 as reproduced in TEST_CASE(define_define_11a).  It thereby also fixes #293.

Subsequent commits in this PR address #66, #130, #241, #296.