### PR TITLE
Multiline Pragma Directive False Positive

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -894,7 +894,7 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
 
             if (newlines > 0 ) {
                 const Token * const llTok = lastLineTok();
-                if (llTok && llTok->op == '#' && llTok->next && llTok->next->str() == "define" && llTok->next->next) {
+                if (llTok && llTok->op == '#' && llTok->next && (llTok->next->str() == "define" || llTok->next->str() == "pragma") && llTok->next->next) {
                     multiline += newlines;
                     location.adjust(s);
                     continue;

--- a/test.cpp
+++ b/test.cpp
@@ -910,6 +910,21 @@ static void define_ifdef()
 
 }
 
+static void pragma_backslash()
+{
+    const char code[] = "#pragma comment (longstring, \\\n"
+                         "\"HEADER\\\n"
+                         "This is a very long string that is\\\n"
+                         "a multi-line string.\\\n"
+                         "How much more do I have to say?\\\n"
+                         "Well, be prepared, because the\\\n"
+                         "story is just beginning. This is a test\\\n"
+                         "string for demonstration purposes. \")\n";
+    
+    simplecpp::OutputList outputList;
+    ASSERT_EQUALS("", preprocess(code, &outputList));
+}
+
 static void dollar()
 {
     ASSERT_EQUALS("$ab", readfile("$ab"));
@@ -2916,6 +2931,8 @@ int main(int argc, char **argv)
     TEST_CASE(define_va_opt_3);
     TEST_CASE(define_va_opt_4);
     TEST_CASE(define_va_opt_5);
+
+    TEST_CASE(pragma_backslash); // multiline pragma directive
 
     // UB: #ifdef as macro parameter
     TEST_CASE(define_ifdef);


### PR DESCRIPTION
When #pragma is a multiline directive, simplecpp doesn't mark the directive as a multiline resulting in a false positive of the end parenthesis ')'.