### PR TITLE
fix #381

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3125,20 +3125,20 @@ static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const
 
 static bool IsFileExists(const std::string& simplePath)
 {
-    if (simplePath.empty())
-    {
-        return false;
-    }
+	if (simplePath.empty())
+	{
+		return false;
+	}
 
-    // This is a workaround to properly check if a file exists,
+	// This is a workaround to properly check if a file exists,
 	// since std::ifstream::good() incorrectly returns true for directories
-    std::fstream fs(simplePath, std::ios::app);
-    if (fs.good())
-    {
-        return true;
-    }
+	std::fstream fs(simplePath, std::ios::in | std::ios::out);
+	if (fs.good())
+	{
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 static std::string getFileName(const std::map<std::string, simplecpp::TokenList *> &filedata, const std::string &sourcefile, const std::string &header, const simplecpp::DUI &dui, bool systemheader)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3123,6 +3123,24 @@ static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const
     return ret;
 }
 
+static bool IsFileExists(const std::string& simplePath)
+{
+    if (simplePath.empty())
+    {
+        return false;
+    }
+
+    // This is a workaround to properly check if a file exists,
+	// since std::ifstream::good() incorrectly returns true for directories
+    std::fstream fs(simplePath, std::ios::app);
+    if (fs.good())
+    {
+        return true;
+    }
+
+    return false;
+}
+
 static std::string getFileName(const std::map<std::string, simplecpp::TokenList *> &filedata, const std::string &sourcefile, const std::string &header, const simplecpp::DUI &dui, bool systemheader)
 {
     if (filedata.empty()) {
@@ -3136,6 +3154,13 @@ static std::string getFileName(const std::map<std::string, simplecpp::TokenList 
         const std::string relativeFilename = getRelativeFileName(sourcefile, header);
         if (filedata.find(relativeFilename) != filedata.end())
             return relativeFilename;
+
+        // If relativeFilename is not found in filedata, check if it exists on disk
+        // If the file exists, load it
+        if (IsFileExists(relativeFilename))
+        {
+            return "";
+        }
     }
 
     for (std::list<std::string>::const_iterator it = dui.includePaths.begin(); it != dui.includePaths.end(); ++it) {


### PR DESCRIPTION
```
std::fstream fs(simplePath, std::ios::app);
```
File existence check using fstream with ios::app is implemented as a workaround because:
 - ifstream::good() incorrectly handles directories on Unix-like systems
 - <sys/stat.h> adds platform-specific dependencies
 - It avoids duplication with CppCheck's 'path' implementation
 - std::filesystem (the proper solution) requires C++17 support

