### PR TITLE
Allow custom pragma processing

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3709,6 +3709,18 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
                 }
             } else if (ifstates.top() == True && rawtok->str() == PRAGMA && rawtok->next && rawtok->next->str() == ONCE && sameline(rawtok,rawtok->next)) {
                 pragmaOnce.insert(rawtok->location.file());
+            } else if (rawtok->str() == PRAGMA) {
+                const Token *start = rawtok->next;
+                if (!start) {
+                    continue;
+                }
+                const Token *end = start->next;
+                while (sameline(rawtok,end)) {
+                    end = end->next;
+                }
+                if (dui.pragmaTokenCallback) {
+                    dui.pragmaTokenCallback(start, end);
+                }
             }
             rawtok = gotoNextLine(rawtok);
             continue;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3715,7 +3715,7 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
                     continue;
                 }
                 const Token *end = start->next;
-                while (sameline(rawtok,end)) {
+                while (end && sameline(rawtok,end) && end->next) {
                     end = end->next;
                 }
                 if (dui.pragmaTokenCallback) {

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -14,6 +14,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <functional>
 
 #ifdef _WIN32
 #  ifdef SIMPLECPP_EXPORT
@@ -337,7 +338,7 @@ namespace simplecpp {
      * On the command line these are configured by -D, -U, -I, --include, -std
      */
     struct SIMPLECPP_LIB DUI {
-        DUI() : clearIncludeCache(false), removeComments(false) {}
+        DUI() : clearIncludeCache(false), removeComments(false), pragmaTokenCallback(nullptr) {}
         std::list<std::string> defines;
         std::set<std::string> undefined;
         std::list<std::string> includePaths;
@@ -345,6 +346,9 @@ namespace simplecpp {
         std::string std;
         bool clearIncludeCache;
         bool removeComments; /** remove comment tokens from included files */
+
+        // Callbacks for handling parts of the token stream
+        std::function<void(const Token *start, const Token *end)> pragmaTokenCallback = nullptr;
     };
 
     SIMPLECPP_LIB long long characterLiteralToLL(const std::string& str);


### PR DESCRIPTION
Since pragmas are one of the few extension points of c++, detecting them seems pretty important for various types of tooling.