### PR TITLE
CI-windows.yml: removed `windows-2019` and added `windows-2025`

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
         config: [Release, Debug]
       fail-fast: false
 
@@ -27,13 +27,7 @@ jobs:
       - name: Setup msbuild.exe
         uses: microsoft/setup-msbuild@v2
         
-      - name: Run cmake
-        if: matrix.os == 'windows-2019'
-        run: |
-          cmake -G "Visual Studio 16 2019" -A x64 . || exit /b !errorlevel!
-
-      - name: Run cmake
-        if: matrix.os == 'windows-2022'
+      - name: Run CMake
         run: |
           cmake -G "Visual Studio 17 2022" -A x64 . || exit /b !errorlevel!
 


### PR DESCRIPTION
`windows-2019` will be removed on June 30 and `windows-2025` is out of preview.