### PR TITLE
fix: parent relative paths, and rework on the whole path extraction mechanics

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: integration test
       run: |
-        python3 -m pytest integration_test.py
+        python3 -m pytest integration_test.py -vv
 
     - name: Run CMake
       run: |

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -57,5 +57,5 @@ jobs:
       - name: integration test
         run: |
           set SIMPLECPP_EXE_PATH=.\${{ matrix.config }}\simplecpp.exe
-          python -m pytest integration_test.py || exit /b !errorlevel!
+          python -m pytest integration_test.py -vv || exit /b !errorlevel!
         

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2725,30 +2725,28 @@ static std::string dirPath(const std::string& path) {
     const std::size_t firstSlash = path.find_last_of("\\/");
     if (firstSlash == std::string::npos) {
         return "";
-    } else {
-        return path.substr(0, firstSlash + (withTrailingSlash ? 1U : 0U));
     }
+    return path.substr(0, firstSlash + (withTrailingSlash ? 1U : 0U));
 }
 
 static std::string omitPathTrailingSlash(const std::string& path) {
     if (endsWith(path, "/")) {
         return path.substr(0, path.size() - 1U);
-    } else {
-        return path;
     }
+    return path;
 }
 
 static std::string extractRelativePathFromAbsolute(const std::string& absoluteSimplifiedPath, const std::string& prefixSimplifiedAbsoluteDir = currentDirectory()) {
     const std::string normalizedAbsolutePath = omitPathTrailingSlash(absoluteSimplifiedPath);
     std::string currentPrefix = omitPathTrailingSlash(prefixSimplifiedAbsoluteDir);
-    std::string leadingParenting = "";
+    std::string leadingParenting;
     while (!startsWith_(normalizedAbsolutePath, currentPrefix)) {
         leadingParenting = "../" + leadingParenting;
         currentPrefix = dirPath<false>(currentPrefix);
     }
     const std::size_t size = currentPrefix.size();
     std::string relativeFromMeetingPath = normalizedAbsolutePath.substr(size, normalizedAbsolutePath.size() - size);
-    if (startsWith_(relativeFromMeetingPath.c_str(), "/")) {
+    if (startsWith_(relativeFromMeetingPath, "/")) {
         // omit the leading slash
         relativeFromMeetingPath = relativeFromMeetingPath.substr(1, relativeFromMeetingPath.size());
     }
@@ -3182,9 +3180,8 @@ static std::string getRelativeFileName(const std::string &baseFile, const std::s
         const std::string absolutePath = expandBaseWithAbsolutePath ? simplifiedPath : toAbsolutePath(simplifiedPath);
         const std::string absoluteBaseFile = expandBaseWithAbsolutePath ? baseFileNormalized : toAbsolutePath(baseFileNormalized);
         return extractRelativePathFromAbsolute(absolutePath, dirPath<true>(absoluteBaseFile));
-    } else {
-        return simplifiedPath;
     }
+    return simplifiedPath;
 }
 
 static std::string openHeaderRelative(std::ifstream &f, const std::string &sourcefile, const std::string &header)
@@ -3253,9 +3250,8 @@ static std::string findPathInMapBothRelativeAndAbsolute(const std::map<std::stri
 
     if (filedata.find(alternativePath) != filedata.end()) {
         return alternativePath;
-    } else {
-        return "";
     }
+    return "";
 }
 
 static std::string getFileIdPath(const std::map<std::string, simplecpp::TokenList *> &filedata, const std::string &sourcefile, const std::string &header, const simplecpp::DUI &dui, bool systemheader)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3297,7 +3297,7 @@ static void safeInsertTokenListToMap(std::map<std::string, simplecpp::TokenList 
     if (!inserted) {
         std::cerr << "error in " << contextDesc << " - attempt to add a tokenized file to the file map, but this file is already in the map! Details:" <<
             "header: " << header << " header2: " << header2 << " source: " << sourcefile << " systemheader: " << systemheader << std::endl;
-        abort();
+        std::abort();
     }
 }
 

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2720,11 +2720,11 @@ static std::string toAbsolutePath(const std::string& path) {
 }
 
 static std::string dirPath(const std::string& path, bool withTrailingSlash=true) {
-    const std::size_t firstSlash = path.find_last_of("\\/");
-    if (firstSlash == std::string::npos) {
+    const std::size_t lastSlash = path.find_last_of("\\/");
+    if (lastSlash == std::string::npos) {
         return "";
     }
-    return path.substr(0, firstSlash + (withTrailingSlash ? 1U : 0U));
+    return path.substr(0, lastSlash + (withTrailingSlash ? 1U : 0U));
 }
 
 static std::string omitPathTrailingSlash(const std::string& path) {

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2744,6 +2744,12 @@ static std::string extractRelativePathFromAbsolute(const std::string& absoluteSi
     }
     const std::size_t size = currentPrefix.size();
     std::string relativeFromMeetingPath = normalizedAbsolutePath.substr(size, normalizedAbsolutePath.size() - size);
+    if (currentPrefix.empty() && !(startsWith_(absoluteSimplifiedPath, "/") && startsWith_(prefixSimplifiedAbsoluteDir, "/"))) {
+        // In the case that there is no common prefix path,
+        //  and at not both of the paths start with `/` (can happen only in Windows paths on distinct partitions),
+        //  return the absolute simplified path as is because no relative path can match.
+        return absoluteSimplifiedPath;
+    }
     if (startsWith_(relativeFromMeetingPath, "/")) {
         // omit the leading slash
         relativeFromMeetingPath = relativeFromMeetingPath.substr(1, relativeFromMeetingPath.size());

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3173,15 +3173,17 @@ static std::string openHeader(std::ifstream &f, const std::string &path)
 template <bool expandBaseWithAbsolutePath, bool exactRelative> 
 static std::string getRelativeFileName(const std::string &baseFile, const std::string &header)
 {
-    const std::string baseFileNormalized = (expandBaseWithAbsolutePath && !isAbsolutePath(baseFile)) ? (currentDirectory() + "/" + baseFile) : baseFile;
-    const std::string path = isAbsolutePath(header) ? header : (dirPath<true>(baseFileNormalized) + header);
-    const std::string simplifiedPath = simplecpp::simplifyPath(path);
+    const std::string baseFileSimplified = simplecpp::simplifyPath(baseFile);
+    const std::string baseFileNormalized = (expandBaseWithAbsolutePath && !isAbsolutePath(baseFileSimplified)) ? (currentDirectory() + "/" + baseFileSimplified) : baseFileSimplified;
+
+    const std::string headerSimplified = simplecpp::simplifyPath(header);
+    const std::string path = isAbsolutePath(headerSimplified) ? headerSimplified : (dirPath<true>(baseFileNormalized) + headerSimplified);
     if (exactRelative) {
-        const std::string absolutePath = expandBaseWithAbsolutePath ? simplifiedPath : toAbsolutePath(simplifiedPath);
+        const std::string absolutePath = expandBaseWithAbsolutePath ? path : toAbsolutePath(path);
         const std::string absoluteBaseFile = expandBaseWithAbsolutePath ? baseFileNormalized : toAbsolutePath(baseFileNormalized);
         return extractRelativePathFromAbsolute(absolutePath, dirPath<true>(absoluteBaseFile));
     }
-    return simplifiedPath;
+    return path;
 }
 
 static std::string openHeaderRelative(std::ifstream &f, const std::string &sourcefile, const std::string &header)

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2719,14 +2719,40 @@ static std::string toAbsolutePath(const std::string& path) {
     return simplecpp::simplifyPath(path);
 }
 
-static std::pair<std::string, bool> extractRelativePathFromAbsolute(const std::string& absolutepath) {
-    static const std::string prefix = currentDirectory() + "/";
-    if (startsWith_(absolutepath, prefix)) {
-        const std::size_t size = prefix.size();
-        return std::make_pair(absolutepath.substr(size, absolutepath.size() - size), true);
+// templated function for compiler optimization opportunities
+template <bool withTrailingSlash>
+static std::string dirPath(const std::string& path) {
+    const std::size_t firstSlash = path.find_last_of("\\/");
+    if (firstSlash == std::string::npos) {
+        return "";
+    } else {
+        return path.substr(0, firstSlash + (withTrailingSlash ? 1U : 0U));
     }
-    // otherwise
-    return std::make_pair("", false);
+}
+
+static std::string omitPathTrailingSlash(const std::string& path) {
+    if (endsWith(path, "/")) {
+        return path.substr(0, path.size() - 1U);
+    } else {
+        return path;
+    }
+}
+
+static std::string extractRelativePathFromAbsolute(const std::string& absoluteSimplifiedPath, const std::string& prefixSimplifiedAbsoluteDir = currentDirectory()) {
+    const std::string normalizedAbsolutePath = omitPathTrailingSlash(absoluteSimplifiedPath);
+    std::string currentPrefix = omitPathTrailingSlash(prefixSimplifiedAbsoluteDir);
+    std::string leadingParenting = "";
+    while (!startsWith_(normalizedAbsolutePath, currentPrefix)) {
+        leadingParenting = "../" + leadingParenting;
+        currentPrefix = dirPath<false>(currentPrefix);
+    }
+    const std::size_t size = currentPrefix.size();
+    std::string relativeFromMeetingPath = normalizedAbsolutePath.substr(size, normalizedAbsolutePath.size() - size);
+    if (startsWith_(relativeFromMeetingPath.c_str(), "/")) {
+        // omit the leading slash
+        relativeFromMeetingPath = relativeFromMeetingPath.substr(1, relativeFromMeetingPath.size());
+    }
+    return leadingParenting + relativeFromMeetingPath;
 }
 
 static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const std::string &sourcefile, const std::string &header, bool systemheader);
@@ -3145,19 +3171,25 @@ static std::string openHeader(std::ifstream &f, const std::string &path)
     return "";
 }
 
+// templated function for compiler optimization opportunities
+template <bool expandBaseWithAbsolutePath, bool exactRelative> 
 static std::string getRelativeFileName(const std::string &baseFile, const std::string &header)
 {
-    std::string path;
-    if (baseFile.find_first_of("\\/") != std::string::npos)
-        path = baseFile.substr(0, baseFile.find_last_of("\\/") + 1U) + header;
-    else
-        path = header;
-    return simplecpp::simplifyPath(path);
+    const std::string baseFileNormalized = (expandBaseWithAbsolutePath && !isAbsolutePath(baseFile)) ? (currentDirectory() + "/" + baseFile) : baseFile;
+    const std::string path = isAbsolutePath(header) ? header : (dirPath<true>(baseFileNormalized) + header);
+    const std::string simplifiedPath = simplecpp::simplifyPath(path);
+    if (exactRelative) {
+        const std::string absolutePath = expandBaseWithAbsolutePath ? simplifiedPath : toAbsolutePath(simplifiedPath);
+        const std::string absoluteBaseFile = expandBaseWithAbsolutePath ? baseFileNormalized : toAbsolutePath(baseFileNormalized);
+        return extractRelativePathFromAbsolute(absolutePath, dirPath<true>(absoluteBaseFile));
+    } else {
+        return simplifiedPath;
+    }
 }
 
 static std::string openHeaderRelative(std::ifstream &f, const std::string &sourcefile, const std::string &header)
 {
-    return openHeader(f, getRelativeFileName(sourcefile, header));
+    return openHeader(f, getRelativeFileName<false, false>(sourcefile, header));
 }
 
 // returns the simplified header path:
@@ -3174,8 +3206,8 @@ static std::string getIncludePathFileName(const std::string &includePath, const 
     std::string basePath = toAbsolutePath(includePath);
     if (!basePath.empty() && basePath[basePath.size()-1U]!='/' && basePath[basePath.size()-1U]!='\\')
         basePath += '/';
-    const std::string absolutesimplifiedHeaderPath = basePath + simplifiedHeader;
-    return extractRelativePathFromAbsolute(absolutesimplifiedHeaderPath).first;
+    const std::string absoluteSimplifiedHeaderPath = basePath + simplifiedHeader;
+    return extractRelativePathFromAbsolute(absoluteSimplifiedHeaderPath);
 }
 
 static std::string openHeaderIncludePath(std::ifstream &f, const simplecpp::DUI &dui, const std::string &header)
@@ -3210,23 +3242,20 @@ static std::string findPathInMapBothRelativeAndAbsolute(const std::map<std::stri
     if (filedata.find(path) != filedata.end()) {// try first to respect the exact match
         return path;
     }
+
     // otherwise - try to use the normalize to the correct representation
+    std::string alternativePath;
     if (isAbsolutePath(path)) {
-        const std::pair<std::string, bool> relativeExtractedResult = extractRelativePathFromAbsolute(path);
-        if (relativeExtractedResult.second) {
-            const std::string relativePath = relativeExtractedResult.first;
-            if (filedata.find(relativePath) != filedata.end()) {
-                return relativePath;
-            }
-        }
+        alternativePath = extractRelativePathFromAbsolute(simplecpp::simplifyPath(path));
     } else {
-        const std::string absolutePath = toAbsolutePath(path);
-        if (filedata.find(absolutePath) != filedata.end()) {
-            return absolutePath;
-        }
+        alternativePath = toAbsolutePath(path);
     }
-    // otherwise
-    return "";
+
+    if (filedata.find(alternativePath) != filedata.end()) {
+        return alternativePath;
+    } else {
+        return "";
+    }
 }
 
 static std::string getFileIdPath(const std::map<std::string, simplecpp::TokenList *> &filedata, const std::string &sourcefile, const std::string &header, const simplecpp::DUI &dui, bool systemheader)
@@ -3243,7 +3272,7 @@ static std::string getFileIdPath(const std::map<std::string, simplecpp::TokenLis
     }
 
     if (!systemheader) {
-        const std::string relativeOrAbsoluteFilename = getRelativeFileName(sourcefile, header);// unknown if absolute or relative, but always simplified
+        const std::string relativeOrAbsoluteFilename = getRelativeFileName<true, true>(sourcefile, header);// unknown if absolute or relative, but always simplified
         const std::string match = findPathInMapBothRelativeAndAbsolute(filedata, relativeOrAbsoluteFilename);
         if (!match.empty()) {
             return match;


### PR DESCRIPTION
- Include also another integration test function to check header in parent dir usage (that was failing in previous commit).
- Add a safety check that we did not meet the header file that we are about to insert to the map (abort with stderr message otherwise) - this not only detect unmet bugs in including paths, but also avoid memory leak.
- Add much more cover in the test functions, and check more details.