### PR TITLE
fix: leak + double header tokenizing in simplecpp::load

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3249,6 +3249,8 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
         if (!f.is_open())
             continue;
         f.close();
+        if (ret.find(header2) != ret.end())
+            continue;
 
         TokenList *tokens = new TokenList(header2, filenames, outputList);
         if (dui.removeComments)


### PR DESCRIPTION
This was catched using the leak sanitizer that is part of the address sanitizer.

On the line `ret[header2] = tokens;`, sometimes there is already a key `header2` in the `ret` map, causing both overriding(leak) and wasteful header tokenizing (two times at least).