### PR TITLE
Fix #391 (`__TIME__` replacement might be empty depending on compiler)

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3440,7 +3440,7 @@ static std::string getDateDefine(const struct tm *timep)
 static std::string getTimeDefine(const struct tm *timep)
 {
     char buf[] = "??:??:??";
-    strftime(buf, sizeof(buf), "%T", timep);
+    strftime(buf, sizeof(buf), "%H:%M:%S", timep);
     return std::string("\"").append(buf).append("\"");
 }
 


### PR DESCRIPTION
The `%T` format specifier for `strftime` is somehow still not implemented in mingw-w64, causing simplecpp to expand `__TIME__` to an empty string. This is an issue with the compiler suite, but the easiest fix is to use the equivalent `%H:%M:%S` instead. C99's `%T` is defined to be equivalent to `%H:%M:%S`, so this change should be  compatible with all implementations supporting `strftime`.