### PR TITLE
Fix #368 (__VA_OPT__ is not handled good enough)

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1956,7 +1956,7 @@ namespace simplecpp {
             const Token *endToken2;
 
             if (variadicOpt) {
-                if (parametertokens2.size() > args.size() && parametertokens2.front()->next->op != ')')
+                if (parametertokens2.size() > args.size() && parametertokens2[args.size() - 1]->next->op != ')')
                     valueToken2 = optExpandValue->cfront();
                 else
                     valueToken2 = optNoExpandValue->cfront();

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1764,7 +1764,7 @@ namespace simplecpp {
                 for (const Token *tok = valueToken; tok && tok != endToken;) {
                     if (tok->str() == "__VA_OPT__") {
                         if (!sameline(tok, tok->next) || tok->next->op != '(')
-                            throw Error(tok->location, "Missing opening parenthesis for __VA_OPT__");
+                            throw Error(tok->location, "In definition of '" + nameTokDef->str() + "': Missing opening parenthesis for __VA_OPT__");
                         tok = tok->next->next;
                         int par = 1;
                         while (tok && tok != endToken) {
@@ -1773,7 +1773,7 @@ namespace simplecpp {
                             else if (tok->op == ')')
                                 par--;
                             else if (tok->str() == "__VA_OPT__")
-                                throw Error(tok->location, "__VA_OPT__ cannot be nested");
+                                throw Error(tok->location, "In definition of '" + nameTokDef->str() + "': __VA_OPT__ cannot be nested");
                             if (par == 0) {
                                 tok = tok->next;
                                 break;
@@ -1783,7 +1783,7 @@ namespace simplecpp {
                         }
                         if (par != 0) {
                             const Token *const lastTok = expandValue.back() ? expandValue.back() : valueToken->next;
-                            throw Error(lastTok->location, "Missing closing parenthesis for __VA_OPT__");
+                            throw Error(lastTok->location, "In definition of '" + nameTokDef->str() + "': Missing closing parenthesis for __VA_OPT__");
                         }
                     } else {
                         expandValue.push_back(new Token(*tok));

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2391,7 +2391,7 @@ namespace simplecpp {
         /** does the macro expansion have __VA_OPT__? */
         bool variadicOpt;
 
-        /** Expansion value for varadic macros with __VA_OPT__ expanded and discarded respecively */
+        /** Expansion value for varadic macros with __VA_OPT__ expanded and discarded respectively */
         const TokenList *optExpandValue;
         const TokenList *optNoExpandValue;
 

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1485,7 +1485,7 @@ namespace simplecpp {
 
     class Macro {
     public:
-        explicit Macro(std::vector<std::string> &f) : nameTokDef(nullptr), valueToken(nullptr), endToken(nullptr), files(f), tokenListDefine(f), variadic(false), valueDefinedInCode_(false) {}
+        explicit Macro(std::vector<std::string> &f) : nameTokDef(nullptr), valueToken(nullptr), endToken(nullptr), files(f), tokenListDefine(f), variadic(false), variadicOpt(false), optExpandValue(nullptr), optNoExpandValue(nullptr), valueDefinedInCode_(false) {}
 
         Macro(const Token *tok, std::vector<std::string> &f) : nameTokDef(nullptr), files(f), tokenListDefine(f), valueDefinedInCode_(true) {
             if (sameline(tok->previousSkipComments(), tok))
@@ -1513,6 +1513,11 @@ namespace simplecpp {
 
         Macro(const Macro &other) : nameTokDef(nullptr), files(other.files), tokenListDefine(other.files), valueDefinedInCode_(other.valueDefinedInCode_) {
             *this = other;
+        }
+
+        ~Macro() {
+            delete optExpandValue;
+            delete optNoExpandValue;
         }
 
         Macro &operator=(const Macro &other) {
@@ -1707,6 +1712,9 @@ namespace simplecpp {
         bool parseDefine(const Token *nametoken) {
             nameTokDef = nametoken;
             variadic = false;
+            variadicOpt = false;
+            optExpandValue = nullptr;
+            optNoExpandValue = nullptr;
             if (!nameTokDef) {
                 valueToken = endToken = nullptr;
                 args.clear();
@@ -1744,8 +1752,52 @@ namespace simplecpp {
             if (!sameline(valueToken, nameTokDef))
                 valueToken = nullptr;
             endToken = valueToken;
-            while (sameline(endToken, nameTokDef))
+            while (sameline(endToken, nameTokDef)) {
+                if (variadic && endToken->str() == "__VA_OPT__")
+                    variadicOpt = true;
                 endToken = endToken->next;
+            }
+
+            if (variadicOpt) {
+                TokenList expandValue(files);
+                TokenList noExpandValue(files);
+                for (const Token *tok = valueToken; tok && tok != endToken;) {
+                    if (tok->str() == "__VA_OPT__") {
+                        if (!sameline(tok, tok->next) || tok->next->op != '(')
+                            throw Error(tok->location, "Missing opening parenthesis for __VA_OPT__");
+                        tok = tok->next->next;
+                        int par = 1;
+                        while (tok && tok != endToken) {
+                            if (tok->op == '(')
+                                par++;
+                            else if (tok->op == ')')
+                                par--;
+                            else if (tok->str() == "__VA_OPT__")
+                                throw Error(tok->location, "__VA_OPT__ cannot be nested");
+                            if (par == 0) {
+                                tok = tok->next;
+                                break;
+                            }
+                            expandValue.push_back(new Token(*tok));
+                            tok = tok->next;
+                        }
+                        if (par != 0)
+                            throw Error(endToken->location, "Missing closing parenthesis for __VA_OPT__");
+                    } else {
+                        expandValue.push_back(new Token(*tok));
+                        noExpandValue.push_back(new Token(*tok));
+                        tok = tok->next;
+                    }
+                }
+#if __cplusplus >= 201103L
+                optExpandValue = new TokenList(std::move(expandValue));
+                optNoExpandValue = new TokenList(std::move(noExpandValue));
+#else
+                optExpandValue = new TokenList(expandValue);
+                optNoExpandValue = new TokenList(noExpandValue);
+#endif
+            }
+
             return true;
         }
 
@@ -1900,8 +1952,22 @@ namespace simplecpp {
 
             Token * const output_end_1 = output->back();
 
+            const Token *valueToken2;
+            const Token *endToken2;
+
+            if (variadicOpt) {
+                if (parametertokens2.size() > args.size() && parametertokens2.front()->next->op != ')')
+                    valueToken2 = optExpandValue->cfront();
+                else
+                    valueToken2 = optNoExpandValue->cfront();
+                endToken2 = nullptr;
+            } else {
+                valueToken2 = valueToken;
+                endToken2 = endToken;
+            }
+
             // expand
-            for (const Token *tok = valueToken; tok != endToken;) {
+            for (const Token *tok = valueToken2; tok != endToken2;) {
                 if (tok->op != '#') {
                     // A##B => AB
                     if (sameline(tok, tok->next) && tok->next && tok->next->op == '#' && tok->next->next && tok->next->next->op == '#') {
@@ -1950,7 +2016,7 @@ namespace simplecpp {
                 }
 
                 tok = tok->next;
-                if (tok == endToken) {
+                if (tok == endToken2) {
                     output->push_back(new Token(*tok->previous));
                     break;
                 }
@@ -2020,24 +2086,6 @@ namespace simplecpp {
             // Macro parameter..
             {
                 TokenList temp(files);
-                if (tok->str() == "__VA_OPT__") {
-                    if (sameline(tok, tok->next) && tok->next->str() == "(") {
-                        tok = tok->next;
-                        int paren = 1;
-                        while (sameline(tok, tok->next)) {
-                            if (tok->next->str() == "(")
-                                ++paren;
-                            else if (tok->next->str() == ")")
-                                --paren;
-                            if (paren == 0)
-                                return tok->next->next;
-                            tok = tok->next;
-                            if (parametertokens.size() > args.size() && parametertokens.front()->next->str() != ")")
-                                tok = expandToken(output, loc, tok, macros, expandedmacros, parametertokens)->previous;
-                        }
-                    }
-                    throw Error(tok->location, "Missing parenthesis for __VA_OPT__(content)");
-                }
                 if (expandArg(&temp, tok, loc, macros, expandedmacros, parametertokens)) {
                     if (tok->str() == "__VA_ARGS__" && temp.empty() && output->cback() && output->cback()->str() == "," &&
                         tok->nextSkipComments() && tok->nextSkipComments()->str() == ")")
@@ -2337,6 +2385,13 @@ namespace simplecpp {
 
         /** is macro variadic? */
         bool variadic;
+
+        /** does the macro expansion have __VA_OPT__? */
+        bool variadicOpt;
+
+        /** Expansion value for varadic macros with __VA_OPT__ expanded and discarded respecively */
+        const TokenList *optExpandValue;
+        const TokenList *optNoExpandValue;
 
         /** was the value of this macro actually defined in the code? */
         bool valueDefinedInCode_;
@@ -3618,6 +3673,16 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
                         err.location = rawtok->location;
                         err.msg = "Failed to parse #define";
                         outputList->push_back(err);
+                    }
+                    output.clear();
+                    return;
+                } catch (simplecpp::Macro::Error &err) {
+                    if (outputList) {
+                        simplecpp::Output out(files);
+                        out.type = simplecpp::Output::SYNTAX_ERROR;
+                        out.location = err.location;
+                        out.msg = "Failed to parse #define, " + err.what;
+                        outputList->push_back(out);
                     }
                     output.clear();
                     return;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1781,8 +1781,10 @@ namespace simplecpp {
                             expandValue.push_back(new Token(*tok));
                             tok = tok->next;
                         }
-                        if (par != 0)
-                            throw Error(endToken->location, "Missing closing parenthesis for __VA_OPT__");
+                        if (par != 0) {
+                            const Token *const lastTok = expandValue.back() ? expandValue.back() : valueToken->next;
+                            throw Error(lastTok->location, "Missing closing parenthesis for __VA_OPT__");
+                        }
                     } else {
                         expandValue.push_back(new Token(*tok));
                         noExpandValue.push_back(new Token(*tok));

--- a/test.cpp
+++ b/test.cpp
@@ -984,6 +984,33 @@ static void define_va_opt_6()
                   toString(outputList));
 }
 
+static void define_va_opt_7()
+{
+    // eof in __VA_OPT__
+    const char code1[] = "#define err(...) __VA_OPT__";
+
+    simplecpp::OutputList outputList;
+    ASSERT_EQUALS("", preprocess(code1, &outputList));
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
+                  toString(outputList));
+
+    outputList.clear();
+
+    const char code2[] = "#define err(...) __VA_OPT__(";
+
+    ASSERT_EQUALS("", preprocess(code2, &outputList));
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
+                  toString(outputList));
+
+    outputList.clear();
+
+    const char code3[] = "#define err(...) __VA_OPT__(x";
+
+    ASSERT_EQUALS("", preprocess(code3, &outputList));
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
+                  toString(outputList));
+}
+
 static void define_ifdef()
 {
     const char code[] = "#define A(X) X\n"
@@ -3076,6 +3103,7 @@ int main(int argc, char **argv)
     TEST_CASE(define_va_opt_4);
     TEST_CASE(define_va_opt_5);
     TEST_CASE(define_va_opt_6);
+    TEST_CASE(define_va_opt_7);
 
     TEST_CASE(pragma_backslash); // multiline pragma directive
 

--- a/test.cpp
+++ b/test.cpp
@@ -923,7 +923,7 @@ static void define_va_opt_3()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code1, &outputList));
-    ASSERT_EQUALS("file0,2,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
                   toString(outputList));
 
     outputList.clear();

--- a/test.cpp
+++ b/test.cpp
@@ -923,7 +923,7 @@ static void define_va_opt_3()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code1, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'err', Missing parenthesis for __VA_OPT__(content)\n",
+    ASSERT_EQUALS("file0,2,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
                   toString(outputList));
 
     outputList.clear();
@@ -934,7 +934,7 @@ static void define_va_opt_3()
                          "err()";
 
     ASSERT_EQUALS("", preprocess(code2, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'err', Missing parenthesis for __VA_OPT__(content)\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 }
 
@@ -946,7 +946,7 @@ static void define_va_opt_4()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code1, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'err', Missing parenthesis for __VA_OPT__(content)\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 
     outputList.clear();
@@ -956,7 +956,7 @@ static void define_va_opt_4()
                          "err()";
 
     ASSERT_EQUALS("", preprocess(code2, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'err', Missing parenthesis for __VA_OPT__(content)\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 }
 
@@ -968,7 +968,19 @@ static void define_va_opt_5()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,failed to expand 'err', Missing parenthesis for __VA_OPT__(content)\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
+                  toString(outputList));
+}
+
+static void define_va_opt_6()
+{
+    // nested __VA_OPT__
+    const char code[] = "#define err(...) __VA_OPT__(__VA_OPT__(something))\n"
+                        "err()";
+
+    simplecpp::OutputList outputList;
+    ASSERT_EQUALS("", preprocess(code, &outputList));
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, __VA_OPT__ cannot be nested\n",
                   toString(outputList));
 }
 
@@ -3063,6 +3075,7 @@ int main(int argc, char **argv)
     TEST_CASE(define_va_opt_3);
     TEST_CASE(define_va_opt_4);
     TEST_CASE(define_va_opt_5);
+    TEST_CASE(define_va_opt_6);
 
     TEST_CASE(pragma_backslash); // multiline pragma directive
 

--- a/test.cpp
+++ b/test.cpp
@@ -923,7 +923,7 @@ static void define_va_opt_3()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code1, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing closing parenthesis for __VA_OPT__\n",
                   toString(outputList));
 
     outputList.clear();
@@ -934,7 +934,7 @@ static void define_va_opt_3()
                          "err()";
 
     ASSERT_EQUALS("", preprocess(code2, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 }
 
@@ -946,7 +946,7 @@ static void define_va_opt_4()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code1, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 
     outputList.clear();
@@ -956,7 +956,7 @@ static void define_va_opt_4()
                          "err()";
 
     ASSERT_EQUALS("", preprocess(code2, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 }
 
@@ -968,7 +968,7 @@ static void define_va_opt_5()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 }
 
@@ -980,7 +980,7 @@ static void define_va_opt_6()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, __VA_OPT__ cannot be nested\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': __VA_OPT__ cannot be nested\n",
                   toString(outputList));
 }
 
@@ -991,7 +991,7 @@ static void define_va_opt_7()
 
     simplecpp::OutputList outputList;
     ASSERT_EQUALS("", preprocess(code1, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing opening parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing opening parenthesis for __VA_OPT__\n",
                   toString(outputList));
 
     outputList.clear();
@@ -999,7 +999,7 @@ static void define_va_opt_7()
     const char code2[] = "#define err(...) __VA_OPT__(";
 
     ASSERT_EQUALS("", preprocess(code2, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing closing parenthesis for __VA_OPT__\n",
                   toString(outputList));
 
     outputList.clear();
@@ -1007,7 +1007,7 @@ static void define_va_opt_7()
     const char code3[] = "#define err(...) __VA_OPT__(x";
 
     ASSERT_EQUALS("", preprocess(code3, &outputList));
-    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, Missing closing parenthesis for __VA_OPT__\n",
+    ASSERT_EQUALS("file0,1,syntax_error,Failed to parse #define, In definition of 'err': Missing closing parenthesis for __VA_OPT__\n",
                   toString(outputList));
 }
 

--- a/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
+++ b/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -E %s | grep '^    printf( "%%s" , "Hello" );$'
+
+#define P( x, ...) printf( x __VA_OPT__(,) __VA_ARGS__ )
+#define PF( x, ...) P( x __VA_OPT__(,) __VA_ARGS__ )
+
+int main()
+{
+    PF( "%s", "Hello" );
+}

--- a/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
+++ b/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
@@ -9,4 +9,5 @@ int main()
     PF( a, );
     PF( a );
     PF( , );
+    PF( );
 }

--- a/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
+++ b/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
@@ -6,8 +6,8 @@
 int main()
 {
     PF( "%s", "Hello" );
-    PF( a, );
-    PF( a );
+    PF( "Hello", );
+    PF( "Hello" );
     PF( , );
     PF( );
 }

--- a/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
+++ b/testsuite/clang-preprocessor-tests/macro_fn_va_opt.c
@@ -6,4 +6,7 @@
 int main()
 {
     PF( "%s", "Hello" );
+    PF( a, );
+    PF( a );
+    PF( , );
 }


### PR DESCRIPTION
Fixes `__VA_OPT__` by expanding it first, before further recursive expansions in variadic macros.

When a variadic macro containing a `__VA_OPT__` token is parsed, the macro is split into a different token list for the two possible cases, where each occurence of `__VA_OPT__` is either expanded and discarded. The correct token list is selected during macro expansion by examining the number of arguments, this way most of the extra processing required is only done once during the macro parsing, and only for variadic macros containing `__VA_OPT__`.
