### PR TITLE
Add caching of conditional directive chains

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3532,6 +3532,7 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
     // AlwaysFalse => drop all code in #if and #else
     enum IfState { True, ElseIsTrue, AlwaysFalse };
     std::stack<int> ifstates;
+    std::stack<const Token *> iftokens;
     ifstates.push(True);
 
     std::stack<const Token *> includetokenstack;
@@ -3855,15 +3856,24 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
                         ifstates.push(AlwaysFalse);
                     else
                         ifstates.push(conditionIsTrue ? True : ElseIsTrue);
+                    iftokens.push(rawtok);
                 } else if (ifstates.top() == True) {
                     ifstates.top() = AlwaysFalse;
+                    iftokens.top()->nextcond = rawtok;
+                    iftokens.top() = rawtok;
                 } else if (ifstates.top() == ElseIsTrue && conditionIsTrue) {
                     ifstates.top() = True;
+                    iftokens.top()->nextcond = rawtok;
+                    iftokens.top() = rawtok;
                 }
             } else if (rawtok->str() == ELSE) {
                 ifstates.top() = (ifstates.top() == ElseIsTrue) ? True : AlwaysFalse;
+                iftokens.top()->nextcond = rawtok;
+                iftokens.top() = rawtok;
             } else if (rawtok->str() == ENDIF) {
                 ifstates.pop();
+                iftokens.top()->nextcond = rawtok;
+                iftokens.pop();
             } else if (rawtok->str() == UNDEF) {
                 if (ifstates.top() == True) {
                     const Token *tok = rawtok->next;
@@ -3875,7 +3885,10 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
             } else if (ifstates.top() == True && rawtok->str() == PRAGMA && rawtok->next && rawtok->next->str() == ONCE && sameline(rawtok,rawtok->next)) {
                 pragmaOnce.insert(rawtok->location.file());
             }
-            rawtok = gotoNextLine(rawtok);
+            if (ifstates.top() != True && rawtok->nextcond)
+                rawtok = rawtok->nextcond->previous;
+            else
+                rawtok = gotoNextLine(rawtok);
             continue;
         }
 

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -96,12 +96,12 @@ namespace simplecpp {
     class SIMPLECPP_LIB Token {
     public:
         Token(const TokenString &s, const Location &loc, bool wsahead = false) :
-            whitespaceahead(wsahead), location(loc), previous(nullptr), next(nullptr), string(s) {
+            whitespaceahead(wsahead), location(loc), previous(nullptr), next(nullptr), nextcond(nullptr), string(s) {
             flags();
         }
 
         Token(const Token &tok) :
-            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), whitespaceahead(tok.whitespaceahead), location(tok.location), previous(nullptr), next(nullptr), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {
+            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), whitespaceahead(tok.whitespaceahead), location(tok.location), previous(nullptr), next(nullptr), nextcond(nullptr), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {
         }
 
         void flags() {
@@ -137,6 +137,7 @@ namespace simplecpp {
         Location location;
         Token *previous;
         Token *next;
+        mutable const Token *nextcond;
 
         const Token *previousSkipComments() const {
             const Token *tok = this->previous;


### PR DESCRIPTION
Adds caching for `elif`, `else`, and `endif` tokens that follow `if`, `elif`, and `else` the first time they're processed, so that the preprocessor can jump directly to them the next time the conditional block should be skipped.

The next conditional token is cached in the previous token's `mutable const Token *nextcond`. Having a public mutable member is a bit awkward but seemed like the best solution. The alternative would be to make `nextcond` private and make `preprocess` a friend, or make preprocess take a non-const `TokenList`.

In the test case that I used for #447 this change brings the runtime down from over 12 minutes to less than one minute.