### PR TITLE
Makefile: added `CXXOPTS` and `LDOPTS` to extend `CXXFLAGS` and `LDFLAGS`

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -80,19 +80,19 @@ jobs:
       if: matrix.os == 'ubuntu-24.04' && matrix.compiler == 'g++'
       run: |
         make clean
-        make -j$(nproc) test selfcheck CXXFLAGS="-g3 -D_GLIBCXX_DEBUG"
+        make -j$(nproc) test selfcheck CXXOPTS="-g3 -D_GLIBCXX_DEBUG"
 
     - name: Run with libc++ hardening mode
       if: matrix.os == 'ubuntu-24.04' && matrix.compiler == 'clang++'
       run: |
         make clean
-        make -j$(nproc) test selfcheck CXXFLAGS="-stdlib=libc++ -g3 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG" LDFLAGS="-lc++"
+        make -j$(nproc) test selfcheck CXXOPTS="-stdlib=libc++ -g3 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG" LDOPTS="-lc++"
 
     - name: Run AddressSanitizer
       if: matrix.os == 'ubuntu-24.04'
       run: |
         make clean
-        make -j$(nproc) test selfcheck CXXFLAGS="-O2 -g3 -fsanitize=address" LDFLAGS="-fsanitize=address"
+        make -j$(nproc) test selfcheck CXXOPTS="-O2 -g3 -fsanitize=address" LDOPTS="-fsanitize=address"
       env:
         ASAN_OPTIONS: detect_stack_use_after_return=1
 
@@ -100,7 +100,7 @@ jobs:
       if: matrix.os == 'ubuntu-24.04'
       run: |
         make clean
-        make -j$(nproc) test selfcheck CXXFLAGS="-O2 -g3 -fsanitize=undefined -fno-sanitize=signed-integer-overflow" LDFLAGS="-fsanitize=undefined -fno-sanitize=signed-integer-overflow"
+        make -j$(nproc) test selfcheck CXXOPTS="-O2 -g3 -fsanitize=undefined -fno-sanitize=signed-integer-overflow" LDOPTS="-fsanitize=undefined -fno-sanitize=signed-integer-overflow"
       env:
         UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:report_error_type=1
 
@@ -109,4 +109,4 @@ jobs:
       if: false && matrix.os == 'ubuntu-24.04' && matrix.compiler == 'clang++'
       run: |
         make clean
-        make -j$(nproc) test selfcheck CXXFLAGS="-O2 -g3 -stdlib=libc++ -fsanitize=memory" LDFLAGS="-lc++ -fsanitize=memory"
+        make -j$(nproc) test selfcheck CXXOPTS="-O2 -g3 -stdlib=libc++ -fsanitize=memory" LDOPTS="-lc++ -fsanitize=memory"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:	testrunner simplecpp
 
-CXXFLAGS = -Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wundef -Wno-multichar -Wold-style-cast -std=c++11 -g
-LDFLAGS = -g
+CXXFLAGS = -Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wundef -Wno-multichar -Wold-style-cast -std=c++11 -g $(CXXOPTS)
+LDFLAGS = -g $(LDOPTS)
 
 %.o: %.cpp	simplecpp.h
 	$(CXX) $(CXXFLAGS) -c $<


### PR DESCRIPTION
Currently it was necessary to duplicate (and keep in sync) all the built-in flags if you just wanted to extend it. This introduced additional variables to make this easier.