### PR TITLE
Fix infinite loop with circular includes

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3109,14 +3109,12 @@ bool simplecpp::FileDataCache::getFileId(const std::string &path, FileID &id)
 #endif
 }
 
-simplecpp::FileDataCache simplecpp::load(const simplecpp::TokenList &rawtokens, std::vector<std::string> &filenames, const simplecpp::DUI &dui, simplecpp::OutputList *outputList)
+simplecpp::FileDataCache simplecpp::load(const simplecpp::TokenList &rawtokens, std::vector<std::string> &filenames, const simplecpp::DUI &dui, simplecpp::OutputList *outputList, FileDataCache cache)
 {
 #ifdef SIMPLECPP_WINDOWS
     if (dui.clearIncludeCache)
         nonExistingFilesCache.clear();
 #endif
-
-    FileDataCache cache;
 
     std::list<const Token *> filelist;
 

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3173,10 +3173,11 @@ simplecpp::FileDataCache simplecpp::load(const simplecpp::TokenList &rawtokens, 
 
         const auto loadResult = cache.get(sourcefile, header, dui, systemheader, filenames, outputList);
         const bool loaded = loadResult.second;
-        FileData *const filedata = loadResult.first;
 
         if (!loaded)
             continue;
+
+        FileData *const filedata = loadResult.first;
 
         if (!filedata->tokens.front())
             continue;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3173,15 +3173,20 @@ simplecpp::FileDataCache simplecpp::load(const simplecpp::TokenList &rawtokens, 
         const bool systemheader = (htok->str()[0] == '<');
         const std::string header(htok->str().substr(1U, htok->str().size() - 2U));
 
-        FileData *const filedata = cache.get(sourcefile, header, dui, systemheader, filenames, outputList).first;
-        if (!filedata)
+        const auto loadResult = cache.get(sourcefile, header, dui, systemheader, filenames, outputList);
+        const bool loaded = loadResult.second;
+        FileData *const filedata = loadResult.first;
+
+        if (!loaded)
+            continue;
+
+        if (!filedata->tokens.front())
             continue;
 
         if (dui.removeComments)
             filedata->tokens.removeComments();
 
-        if (filedata->tokens.front())
-            filelist.push_back(filedata->tokens.front());
+        filelist.push_back(filedata->tokens.front());
     }
 
     return cache;

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -353,49 +353,6 @@ namespace simplecpp {
         bool removeComments; /** remove comment tokens from included files */
     };
 
-    SIMPLECPP_LIB long long characterLiteralToLL(const std::string& str);
-
-    SIMPLECPP_LIB FileDataCache load(const TokenList &rawtokens, std::vector<std::string> &filenames, const DUI &dui, OutputList *outputList = nullptr);
-
-    /**
-     * Preprocess
-     * @todo simplify interface
-     * @param output TokenList that receives the preprocessing output
-     * @param rawtokens Raw tokenlist for top sourcefile
-     * @param files internal data of simplecpp
-     * @param cache output from simplecpp::load()
-     * @param dui defines, undefs, and include paths
-     * @param outputList output: list that will receive output messages
-     * @param macroUsage output: macro usage
-     * @param ifCond output: #if/#elif expressions
-     */
-    SIMPLECPP_LIB void preprocess(TokenList &output, const TokenList &rawtokens, std::vector<std::string> &files, FileDataCache &cache, const DUI &dui, OutputList *outputList = nullptr, std::list<MacroUsage> *macroUsage = nullptr, std::list<IfCond> *ifCond = nullptr);
-
-    /**
-     * Deallocate data
-     */
-    SIMPLECPP_LIB void cleanup(FileDataCache &cache);
-
-    /** Simplify path */
-    SIMPLECPP_LIB std::string simplifyPath(std::string path);
-
-    /** Convert Cygwin path to Windows path */
-    SIMPLECPP_LIB std::string convertCygwinToWindowsPath(const std::string &cygwinPath);
-
-    /** Returns the C version a given standard */
-    SIMPLECPP_LIB cstd_t getCStd(const std::string &std);
-
-    /** Returns the C++ version a given standard */
-    SIMPLECPP_LIB cppstd_t getCppStd(const std::string &std);
-
-    /** Returns the __STDC_VERSION__ value for a given standard */
-    SIMPLECPP_LIB std::string getCStdString(const std::string &std);
-    SIMPLECPP_LIB std::string getCStdString(cstd_t std);
-
-    /** Returns the __cplusplus value for a given standard */
-    SIMPLECPP_LIB std::string getCppStdString(const std::string &std);
-    SIMPLECPP_LIB std::string getCppStdString(cppstd_t std);
-
     struct SIMPLECPP_LIB FileData {
         /** The canonical filename associated with this data */
         std::string filename;
@@ -503,8 +460,50 @@ namespace simplecpp {
         container_type mData;
         name_map_type mNameMap;
         id_map_type mIdMap;
-
     };
+
+    SIMPLECPP_LIB long long characterLiteralToLL(const std::string& str);
+
+    SIMPLECPP_LIB FileDataCache load(const TokenList &rawtokens, std::vector<std::string> &filenames, const DUI &dui, OutputList *outputList = nullptr, FileDataCache cache = {});
+
+    /**
+     * Preprocess
+     * @todo simplify interface
+     * @param output TokenList that receives the preprocessing output
+     * @param rawtokens Raw tokenlist for top sourcefile
+     * @param files internal data of simplecpp
+     * @param cache output from simplecpp::load()
+     * @param dui defines, undefs, and include paths
+     * @param outputList output: list that will receive output messages
+     * @param macroUsage output: macro usage
+     * @param ifCond output: #if/#elif expressions
+     */
+    SIMPLECPP_LIB void preprocess(TokenList &output, const TokenList &rawtokens, std::vector<std::string> &files, FileDataCache &cache, const DUI &dui, OutputList *outputList = nullptr, std::list<MacroUsage> *macroUsage = nullptr, std::list<IfCond> *ifCond = nullptr);
+
+    /**
+     * Deallocate data
+     */
+    SIMPLECPP_LIB void cleanup(FileDataCache &cache);
+
+    /** Simplify path */
+    SIMPLECPP_LIB std::string simplifyPath(std::string path);
+
+    /** Convert Cygwin path to Windows path */
+    SIMPLECPP_LIB std::string convertCygwinToWindowsPath(const std::string &cygwinPath);
+
+    /** Returns the C version a given standard */
+    SIMPLECPP_LIB cstd_t getCStd(const std::string &std);
+
+    /** Returns the C++ version a given standard */
+    SIMPLECPP_LIB cppstd_t getCppStd(const std::string &std);
+
+    /** Returns the __STDC_VERSION__ value for a given standard */
+    SIMPLECPP_LIB std::string getCStdString(const std::string &std);
+    SIMPLECPP_LIB std::string getCStdString(cstd_t std);
+
+    /** Returns the __cplusplus value for a given standard */
+    SIMPLECPP_LIB std::string getCppStdString(const std::string &std);
+    SIMPLECPP_LIB std::string getCppStdString(cppstd_t std);
 }
 
 #if defined(_MSC_VER)

--- a/test.cpp
+++ b/test.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define STRINGIZE_(x) #x
@@ -2093,7 +2094,7 @@ static void circularInclude()
     simplecpp::FileDataCache cache;
 
     {
-        const char *path = "test.h";
+        const char *const path = "test.h";
         const char code[] =
             "#ifndef TEST_H\n"
             "#define TEST_H\n"
@@ -2104,7 +2105,7 @@ static void circularInclude()
     }
 
     {
-        const char *path = "a/a.h";
+        const char *const path = "a/a.h";
         const char code[] =
             "#ifndef A_H\n"
             "#define A_H\n"
@@ -2117,7 +2118,7 @@ static void circularInclude()
     simplecpp::OutputList outputList;
     {
         std::vector<std::string> filenames;
-        simplecpp::DUI dui;
+        const simplecpp::DUI dui;
 
         const char code[] = "#include \"test.h\"\n";
         const simplecpp::TokenList rawtokens = makeTokenList(code, files, "test.cpp");

--- a/test.cpp
+++ b/test.cpp
@@ -2116,6 +2116,7 @@ static void circularInclude()
     }
 
     simplecpp::OutputList outputList;
+    simplecpp::TokenList tokens2(files);
     {
         std::vector<std::string> filenames;
         const simplecpp::DUI dui;
@@ -2123,7 +2124,8 @@ static void circularInclude()
         const char code[] = "#include \"test.h\"\n";
         const simplecpp::TokenList rawtokens = makeTokenList(code, files, "test.cpp");
 
-        simplecpp::load(rawtokens, filenames, dui, &outputList, std::move(cache));
+        cache = simplecpp::load(rawtokens, filenames, dui, &outputList, std::move(cache));
+        simplecpp::preprocess(tokens2, rawtokens, files, cache, dui, &outputList);
     }
 
     ASSERT_EQUALS("", toString(outputList));


### PR DESCRIPTION
Fix infinite loop in `simplecpp::load` with circular includes by removing scans of cached files.