### PR TITLE
Improve runastyle scripts and update astyle version

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,15 @@
+# style
+--style=kr
+--indent=spaces=4
+--indent-namespaces
+--lineend=linux
+--min-conditional-indent=0
+
+# options
+--pad-header
+--unpad-paren
+--suffix=none
+--convert-tabs
+--attach-inlines
+--attach-classes
+--attach-namespaces

--- a/runastyle
+++ b/runastyle
@@ -15,6 +15,17 @@ ASTYLE_VERSION="3.4.13"
 ASTYLE_VERSION_STR="Artistic Style Version ${ASTYLE_VERSION}"
 ASTYLE="astyle"
 
+if command -v astyle &> /dev/null; then
+    ASTYLE="astyle"
+elif command -v uvx &> /dev/null; then
+    ASTYLE="uvx --quiet ${ASTYLE}==${ASTYLE_VERSION}"
+elif command -v pipx &> /dev/null; then
+    ASTYLE="pipx run --quiet ${ASTYLE}==${ASTYLE_VERSION}"
+else
+    echo "Neither astyle, uvx, nor pipx found in PATH"
+    exit 1
+fi
+
 DETECTED_VERSION_STR=`$ASTYLE --version 2>&1`
 if [[ "$DETECTED_VERSION_STR" != ${ASTYLE_VERSION_STR}* ]]; then
     echo "You should use: ${ASTYLE_VERSION_STR}";

--- a/runastyle
+++ b/runastyle
@@ -20,8 +20,5 @@ if [[ "$DETECTED_VERSION" != ${ASTYLE_VERSION}* ]]; then
     exit 1;
 fi
 
-style="--style=kr --indent=spaces=4 --indent-namespaces --lineend=linux --min-conditional-indent=0"
-options="--options=none --pad-header --unpad-paren --suffix=none --convert-tabs --attach-inlines --attach-classes --attach-namespaces"
-
-$ASTYLE $style $options *.cpp
-$ASTYLE $style $options *.h
+$ASTYLE --options="$SCRIPT_DIR/.astylerc" *.cpp
+$ASTYLE --options="$SCRIPT_DIR/.astylerc" *.h

--- a/runastyle
+++ b/runastyle
@@ -34,5 +34,4 @@ if [[ "$DETECTED_VERSION_STR" != ${ASTYLE_VERSION_STR}* ]]; then
 fi
 
 # Run astyle with the project config
-$ASTYLE --project *.cpp
-$ASTYLE --project *.h
+$ASTYLE --project *.h,*.cpp

--- a/runastyle
+++ b/runastyle
@@ -11,7 +11,7 @@ cd $SCRIPT_DIR
 # To require a newer astyle version, update ASTYLE_VERSION below.
 # ASTYLE_VERSION_STR is then constructed to match the beginning of the
 # version string reported by "astyle --version".
-ASTYLE_VERSION="3.0.1"
+ASTYLE_VERSION="3.4.13"
 ASTYLE_VERSION_STR="Artistic Style Version ${ASTYLE_VERSION}"
 ASTYLE="astyle"
 
@@ -22,5 +22,6 @@ if [[ "$DETECTED_VERSION_STR" != ${ASTYLE_VERSION_STR}* ]]; then
     exit 1;
 fi
 
-$ASTYLE --options="$SCRIPT_DIR/.astylerc" *.cpp
-$ASTYLE --options="$SCRIPT_DIR/.astylerc" *.h
+# Run astyle with the project config
+$ASTYLE --project *.cpp
+$ASTYLE --project *.h

--- a/runastyle
+++ b/runastyle
@@ -4,6 +4,10 @@
 # different versions might have different output (this has happened in
 # the past).
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd $SCRIPT_DIR
+
 # If project management wishes to take a newer astyle version into use
 # just change this string to match the start of astyle version string.
 ASTYLE_VERSION="Artistic Style Version 3.0.1"

--- a/runastyle
+++ b/runastyle
@@ -8,15 +8,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd $SCRIPT_DIR
 
-# If project management wishes to take a newer astyle version into use
-# just change this string to match the start of astyle version string.
-ASTYLE_VERSION="Artistic Style Version 3.0.1"
+# To require a newer astyle version, update ASTYLE_VERSION below.
+# ASTYLE_VERSION_STR is then constructed to match the beginning of the
+# version string reported by "astyle --version".
+ASTYLE_VERSION="3.0.1"
+ASTYLE_VERSION_STR="Artistic Style Version ${ASTYLE_VERSION}"
 ASTYLE="astyle"
 
-DETECTED_VERSION=`$ASTYLE --version 2>&1`
-if [[ "$DETECTED_VERSION" != ${ASTYLE_VERSION}* ]]; then
-    echo "You should use: ${ASTYLE_VERSION}";
-    echo "Detected: ${DETECTED_VERSION}"
+DETECTED_VERSION_STR=`$ASTYLE --version 2>&1`
+if [[ "$DETECTED_VERSION_STR" != ${ASTYLE_VERSION_STR}* ]]; then
+    echo "You should use: ${ASTYLE_VERSION_STR}";
+    echo "Detected: ${DETECTED_VERSION_STR}"
     exit 1;
 fi
 

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -1,25 +1,26 @@
-@REM Script to run AStyle on the sources
-@REM The version check in this script is used to avoid commit battles
-@REM between different developers that use different astyle versions as
-@REM different versions might have different output (this has happened in
-@REM the past).
+@ECHO off
+REM Script to run AStyle on the sources
+REM The version check in this script is used to avoid commit battles
+REM between different developers that use different astyle versions as
+REM different versions might have different output (this has happened in
+REM the past).
 
-@REM Get the directory of the script
+REM Get the directory of the script
 SET SCRIPT_DIR=%~dp0
 
-@REM Change to that directory
+REM Change to that directory
 CD /d %SCRIPT_DIR%
 
-@REM To require a newer astyle version, update ASTYLE_VERSION below.
-@REM ASTYLE_VERSION_STR is then constructed to match the beginning of the
-@REM version string reported by "astyle --version".
-@SET ASTYLE_VERSION="3.0.1"
-@SET ASTYLE_VERSION_STR="Artistic Style Version %ASTYLE_VERSION%"
-@SET ASTYLE="astyle"
+REM To require a newer astyle version, update ASTYLE_VERSION below.
+REM ASTYLE_VERSION_STR is then constructed to match the beginning of the
+REM version string reported by "astyle --version".
+SET ASTYLE_VERSION="3.0.1"
+SET ASTYLE_VERSION_STR="Artistic Style Version %ASTYLE_VERSION%"
+SET ASTYLE="astyle"
 
-@SET DETECTED_VERSION_STR=""
-@FOR /F "tokens=*" %%i IN ('%ASTYLE% --version') DO SET DETECTED_VERSION_STR=%%i
-@ECHO %DETECTED_VERSION_STR% | FINDSTR /B /C:%ASTYLE_VERSION_STR% > nul && (
+SET DETECTED_VERSION_STR=""
+FOR /F "tokens=*" %%i IN ('%ASTYLE% --version') DO SET DETECTED_VERSION_STR=%%i
+ECHO %DETECTED_VERSION_STR% | FINDSTR /B /C:%ASTYLE_VERSION_STR% > nul && (
     ECHO "%DETECTED_VERSION_STR%" matches %ASTYLE_VERSION_STR%
 ) || (
     ECHO You should use: %ASTYLE_VERSION_STR%

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -4,6 +4,12 @@
 @REM different versions might have different output (this has happened in
 @REM the past).
 
+@REM Get the directory of the script
+SET SCRIPT_DIR=%~dp0
+
+@REM Change to that directory
+CD /d %SCRIPT_DIR%
+
 @REM If project management wishes to take a newer astyle version into use
 @REM just change this string to match the start of astyle version string.
 @SET ASTYLE_VERSION="Artistic Style Version 3.0.1"

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -14,7 +14,7 @@ CD /d %SCRIPT_DIR%
 REM To require a newer astyle version, update ASTYLE_VERSION below.
 REM ASTYLE_VERSION_STR is then constructed to match the beginning of the
 REM version string reported by "astyle --version".
-SET ASTYLE_VERSION="3.0.1"
+SET ASTYLE_VERSION="3.4.13"
 SET ASTYLE_VERSION_STR="Artistic Style Version %ASTYLE_VERSION%"
 SET ASTYLE="astyle"
 
@@ -28,8 +28,9 @@ ECHO %DETECTED_VERSION_STR% | FINDSTR /B /C:%ASTYLE_VERSION_STR% > nul && (
     GOTO EXIT_ERROR
 )
 
-%ASTYLE% --options="%SCRIPT_DIR%/.astylerc" *.cpp
-%ASTYLE% --options="%SCRIPT_DIR%/.astylerc" *.h
+REM Run astyle with the project config
+%ASTYLE% --project *.cpp
+%ASTYLE% --project *.h
 GOTO :EOF
 
 :EXIT_ERROR

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -25,8 +25,5 @@ CD /d %SCRIPT_DIR%
     GOTO EXIT_ERROR
 )
 
-@SET STYLE=--style=kr --indent=spaces=4 --indent-namespaces --lineend=linux --min-conditional-indent=0
-@SET OPTIONS=--pad-header --unpad-paren --suffix=none --convert-tabs --attach-inlines --attach-classes --attach-namespaces
-
-%ASTYLE% %STYLE% %OPTIONS% *.cpp
-%ASTYLE% %STYLE% %OPTIONS% *.h
+%ASTYLE% --options="%SCRIPT_DIR%/.astylerc" *.cpp
+%ASTYLE% --options="%SCRIPT_DIR%/.astylerc" *.h

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -30,3 +30,7 @@ ECHO %DETECTED_VERSION_STR% | FINDSTR /B /C:%ASTYLE_VERSION_STR% > nul && (
 
 %ASTYLE% --options="%SCRIPT_DIR%/.astylerc" *.cpp
 %ASTYLE% --options="%SCRIPT_DIR%/.astylerc" *.h
+GOTO :EOF
+
+:EXIT_ERROR
+EXIT /b 1

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -10,18 +10,20 @@ SET SCRIPT_DIR=%~dp0
 @REM Change to that directory
 CD /d %SCRIPT_DIR%
 
-@REM If project management wishes to take a newer astyle version into use
-@REM just change this string to match the start of astyle version string.
-@SET ASTYLE_VERSION="Artistic Style Version 3.0.1"
+@REM To require a newer astyle version, update ASTYLE_VERSION below.
+@REM ASTYLE_VERSION_STR is then constructed to match the beginning of the
+@REM version string reported by "astyle --version".
+@SET ASTYLE_VERSION="3.0.1"
+@SET ASTYLE_VERSION_STR="Artistic Style Version %ASTYLE_VERSION%"
 @SET ASTYLE="astyle"
 
-@SET DETECTED_VERSION=""
-@FOR /F "tokens=*" %%i IN ('%ASTYLE% --version') DO SET DETECTED_VERSION=%%i
-@ECHO %DETECTED_VERSION% | FINDSTR /B /C:%ASTYLE_VERSION% > nul && (
-    ECHO "%DETECTED_VERSION%" matches %ASTYLE_VERSION%
+@SET DETECTED_VERSION_STR=""
+@FOR /F "tokens=*" %%i IN ('%ASTYLE% --version') DO SET DETECTED_VERSION_STR=%%i
+@ECHO %DETECTED_VERSION_STR% | FINDSTR /B /C:%ASTYLE_VERSION_STR% > nul && (
+    ECHO "%DETECTED_VERSION_STR%" matches %ASTYLE_VERSION_STR%
 ) || (
-    ECHO You should use: %ASTYLE_VERSION%
-    ECHO Detected: "%DETECTED_VERSION%"
+    ECHO You should use: %ASTYLE_VERSION_STR%
+    ECHO Detected: "%DETECTED_VERSION_STR%"
     GOTO EXIT_ERROR
 )
 

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -46,8 +46,7 @@ ECHO %DETECTED_VERSION_STR% | FINDSTR /B /C:%ASTYLE_VERSION_STR% > nul && (
 )
 
 REM Run astyle with the project config
-%ASTYLE% --project *.cpp
-%ASTYLE% --project *.h
+%ASTYLE% --project *.h,*.cpp
 GOTO :EOF
 
 :EXIT_ERROR

--- a/runastyle.bat
+++ b/runastyle.bat
@@ -16,7 +16,24 @@ REM ASTYLE_VERSION_STR is then constructed to match the beginning of the
 REM version string reported by "astyle --version".
 SET ASTYLE_VERSION="3.4.13"
 SET ASTYLE_VERSION_STR="Artistic Style Version %ASTYLE_VERSION%"
-SET ASTYLE="astyle"
+
+REM Prefer system astyle; else try uvx; else pipx
+SET "ASTYLE=astyle"
+where astyle >nul 2>nul
+IF %errorlevel% neq 0 (
+  where uvx >nul 2>nul
+  IF %errorlevel% eq 0 (
+    SET "ASTYLE=uvx --quiet astyle==%ASTYLE_VERSION%"
+  ) ELSE (
+    where pipx >nul 2>nul
+    IF %errorlevel% eq 0 (
+      SET "ASTYLE=pipx run --quiet astyle==%ASTYLE_VERSION%"
+    ) ELSE (
+      ECHO ERROR: Neither astyle, uvx, nor pipx found in PATH.
+      GOTO EXIT_ERROR
+    )
+  )
+)
 
 SET DETECTED_VERSION_STR=""
 FOR /F "tokens=*" %%i IN ('%ASTYLE% --version') DO SET DETECTED_VERSION_STR=%%i

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -761,18 +761,18 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
             while (stream.good() && ch != '\n') {
                 currentToken += ch;
                 ch = stream.readChar();
-                if(ch == '\\') {
+                if (ch == '\\') {
                     TokenString tmp;
                     char tmp_ch = ch;
-                    while((stream.good()) && (tmp_ch == '\\' || tmp_ch == ' ' || tmp_ch == '\t')) {
+                    while ((stream.good()) && (tmp_ch == '\\' || tmp_ch == ' ' || tmp_ch == '\t')) {
                         tmp += tmp_ch;
                         tmp_ch = stream.readChar();
                     }
-                    if(!stream.good()) {
+                    if (!stream.good()) {
                         break;
                     }
 
-                    if(tmp_ch != '\n') {
+                    if (tmp_ch != '\n') {
                         currentToken += tmp;
                     } else {
                         const TokenString check_portability = currentToken + tmp;

--- a/test.cpp
+++ b/test.cpp
@@ -438,14 +438,14 @@ static void comment_multiline()
     ASSERT_EQUALS("\n\nvoid f ( ) {", preprocess(code));
 
     const char code1[] = "#define ABC {// \\\r\n"
-                        "}\n"
-                        "void f() ABC\n";
+                         "}\n"
+                         "void f() ABC\n";
     ASSERT_EQUALS("\n\nvoid f ( ) {", preprocess(code1));
 
     const char code2[] = "#define A 1// \\\r"
-                        "\r"
-                        "2\r"
-                        "A\r";
+                         "\r"
+                         "2\r"
+                         "A\r";
     ASSERT_EQUALS("\n\n2\n1", preprocess(code2));
 
     const char code3[] = "void f() {// \\ \n}\n";
@@ -2100,7 +2100,7 @@ static void circularInclude()
             "#define TEST_H\n"
             "#include \"a/a.h\"\n"
             "#endif\n"
-        ;
+            ;
         cache.insert({path, makeTokenList(code, files, path)});
     }
 
@@ -2111,7 +2111,7 @@ static void circularInclude()
             "#define A_H\n"
             "#include \"../test.h\"\n"
             "#endif\n"
-        ;
+            ;
         cache.insert({path, makeTokenList(code, files, path)});
     }
 
@@ -3176,7 +3176,8 @@ static void fuzz_crash()
                             "n\n";
         (void)preprocess(code, simplecpp::DUI()); // do not crash
     }
-    { // #346
+    {
+        // #346
         const char code[] = "#define foo(intp)f##oo(intp\n"
                             "foo(f##oo(intp))\n";
         (void)preprocess(code, simplecpp::DUI()); // do not crash


### PR DESCRIPTION
This pull request improve the runastyle scripts for easier use:

- Ensure the scripts can be executed from any location.
- Centralize astyle configuration with a `.astylerc` file.
- Require astyle 3.4.13 (also available on PyPI) to preserve current formatting; newer 3.6.9 alters continuation-line indentation.
- Add support for command runners like `pipx` and `uvx` if `astyle` is not available in the `PATH`.
- Simplify the batch script with "@echo off" and proper error handling.
- Combine astyle invocations for `.h` and `.cpp` files into a single command.
- Format source files according to the updated style guidelines.