### PR TITLE
tests: Fix execution of testrunner for out-of-source builds

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -73,6 +73,9 @@ jobs:
       run: |
         cmake --build cmake.output --target testrunner -- -j $(nproc)
         ./cmake.output/testrunner
+        # Re-run tests from within the build directory to validate that
+        # SIMPLECPP_TEST_SOURCE_DIR is correctly defined and resolved
+        (cd cmake.output && ./testrunner)
 
     - name: Run valgrind
       if: matrix.os == 'ubuntu-24.04'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ add_executable(simplecpp $<TARGET_OBJECTS:simplecpp_obj> main.cpp)
 add_executable(testrunner $<TARGET_OBJECTS:simplecpp_obj> test.cpp)
 target_compile_definitions(testrunner
     PRIVATE
-        SIMPLECPP_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+        SIMPLECPP_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ add_library(simplecpp_obj OBJECT simplecpp.cpp)
 
 add_executable(simplecpp $<TARGET_OBJECTS:simplecpp_obj> main.cpp)
 add_executable(testrunner $<TARGET_OBJECTS:simplecpp_obj> test.cpp)
+target_compile_definitions(testrunner
+    PRIVATE
+        SIMPLECPP_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
 
 enable_testing()
 add_test(NAME testrunner COMMAND testrunner)

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,14 @@ all:	testrunner simplecpp
 CXXFLAGS = -Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wundef -Wno-multichar -Wold-style-cast -std=c++11 -g $(CXXOPTS)
 LDFLAGS = -g $(LDOPTS)
 
+# Define test source dir macro for compilation
+TEST_DEFINES = -DSIMPLECPP_TEST_SOURCE_DIR=\"$(CURDIR)\"
+
+# Only test.o gets the define
+test.o: CXXFLAGS += $(TEST_DEFINES)
+
 %.o: %.cpp	simplecpp.h
 	$(CXX) $(CXXFLAGS) -c $<
-
 
 testrunner:	test.o	simplecpp.o
 	$(CXX) $(LDFLAGS) simplecpp.o test.o -o testrunner

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 all:	testrunner simplecpp
 
+CPPFLAGS ?=
 CXXFLAGS = -Wall -Wextra -pedantic -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wredundant-decls -Wundef -Wno-multichar -Wold-style-cast -std=c++11 -g $(CXXOPTS)
 LDFLAGS = -g $(LDOPTS)
 
-# Define test source dir macro for compilation
-TEST_DEFINES = -DSIMPLECPP_TEST_SOURCE_DIR=\"$(CURDIR)\"
+# Define test source dir macro for compilation (preprocessor flags)
+TEST_CPPFLAGS = -DSIMPLECPP_TEST_SOURCE_DIR=\"$(CURDIR)\"
 
 # Only test.o gets the define
-test.o: CXXFLAGS += $(TEST_DEFINES)
+test.o: CPPFLAGS += $(TEST_CPPFLAGS)
 
 %.o: %.cpp	simplecpp.h
-	$(CXX) $(CXXFLAGS) -c $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $<
 
 testrunner:	test.o	simplecpp.o
 	$(CXX) $(LDFLAGS) simplecpp.o test.o -o testrunner

--- a/test.cpp
+++ b/test.cpp
@@ -23,6 +23,7 @@
 #define STRINGIZE_(x) #x
 #define STRINGIZE(x) STRINGIZE_(x)
 
+static const std::string testSourceDir = SIMPLECPP_TEST_SOURCE_DIR;
 static int numberOfFailedAssertions = 0;
 
 #define ASSERT_EQUALS(expected, actual)  (assertEquals((expected), (actual), __LINE__))
@@ -1560,7 +1561,7 @@ static void has_include_1()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
-    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
+    dui.includePaths.push_back(testSourceDir);
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     dui.std = "c++14";
@@ -1578,7 +1579,7 @@ static void has_include_2()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
-    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
+    dui.includePaths.push_back(testSourceDir);
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
@@ -1598,7 +1599,7 @@ static void has_include_3()
     // Test file not found...
     ASSERT_EQUALS("\n\n\n\nB", preprocess(code, dui));
     // Unless -I is set (preferably, we should differentiate -I and -isystem...)
-    dui.includePaths.push_back(std::string(SIMPLECPP_TEST_SOURCE_DIR) + "/testsuite");
+    dui.includePaths.push_back(testSourceDir + "/testsuite");
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1614,7 +1615,7 @@ static void has_include_4()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
-    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
+    dui.includePaths.push_back(testSourceDir);
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1630,7 +1631,7 @@ static void has_include_5()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
-    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
+    dui.includePaths.push_back(testSourceDir);
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1646,7 +1647,7 @@ static void has_include_6()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "gnu99";
-    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
+    dui.includePaths.push_back(testSourceDir);
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }

--- a/test.cpp
+++ b/test.cpp
@@ -16,6 +16,10 @@
 #include <utility>
 #include <vector>
 
+#ifndef SIMPLECPP_TEST_SOURCE_DIR
+#error "SIMPLECPP_TEST_SOURCE_DIR is not defined."
+#endif
+
 #define STRINGIZE_(x) #x
 #define STRINGIZE(x) STRINGIZE_(x)
 
@@ -1556,9 +1560,7 @@ static void has_include_1()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
-#ifdef SIMPLECPP_TEST_SOURCE_DIR
     dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
-#endif
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     dui.std = "c++14";
@@ -1576,9 +1578,7 @@ static void has_include_2()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
-#ifdef SIMPLECPP_TEST_SOURCE_DIR
     dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
-#endif
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
@@ -1598,11 +1598,7 @@ static void has_include_3()
     // Test file not found...
     ASSERT_EQUALS("\n\n\n\nB", preprocess(code, dui));
     // Unless -I is set (preferably, we should differentiate -I and -isystem...)
-#ifdef SIMPLECPP_TEST_SOURCE_DIR
     dui.includePaths.push_back(std::string(SIMPLECPP_TEST_SOURCE_DIR) + "/testsuite");
-#else
-    dui.includePaths.push_back("./testsuite");
-#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1618,9 +1614,7 @@ static void has_include_4()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
-#ifdef SIMPLECPP_TEST_SOURCE_DIR
     dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
-#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1636,9 +1630,7 @@ static void has_include_5()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
-#ifdef SIMPLECPP_TEST_SOURCE_DIR
     dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
-#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1654,9 +1646,7 @@ static void has_include_6()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "gnu99";
-#ifdef SIMPLECPP_TEST_SOURCE_DIR
     dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
-#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }

--- a/test.cpp
+++ b/test.cpp
@@ -1556,8 +1556,8 @@ static void has_include_1()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
-#ifdef SIMPLECPP_SOURCE_DIR
-    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#ifdef SIMPLECPP_TEST_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
 #endif
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
@@ -1576,8 +1576,8 @@ static void has_include_2()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
-#ifdef SIMPLECPP_SOURCE_DIR
-    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#ifdef SIMPLECPP_TEST_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
 #endif
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
@@ -1598,8 +1598,8 @@ static void has_include_3()
     // Test file not found...
     ASSERT_EQUALS("\n\n\n\nB", preprocess(code, dui));
     // Unless -I is set (preferably, we should differentiate -I and -isystem...)
-#ifdef SIMPLECPP_SOURCE_DIR
-    dui.includePaths.push_back(std::string(SIMPLECPP_SOURCE_DIR) + "/testsuite");
+#ifdef SIMPLECPP_TEST_SOURCE_DIR
+    dui.includePaths.push_back(std::string(SIMPLECPP_TEST_SOURCE_DIR) + "/testsuite");
 #else
     dui.includePaths.push_back("./testsuite");
 #endif
@@ -1618,8 +1618,8 @@ static void has_include_4()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
-#ifdef SIMPLECPP_SOURCE_DIR
-    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#ifdef SIMPLECPP_TEST_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
 #endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
@@ -1636,8 +1636,8 @@ static void has_include_5()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
-#ifdef SIMPLECPP_SOURCE_DIR
-    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#ifdef SIMPLECPP_TEST_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
 #endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
@@ -1654,8 +1654,8 @@ static void has_include_6()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "gnu99";
-#ifdef SIMPLECPP_SOURCE_DIR
-    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#ifdef SIMPLECPP_TEST_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_TEST_SOURCE_DIR);
 #endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));

--- a/test.cpp
+++ b/test.cpp
@@ -1556,6 +1556,9 @@ static void has_include_1()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
+#ifdef SIMPLECPP_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#endif
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     dui.std = "c++14";
@@ -1573,6 +1576,9 @@ static void has_include_2()
                         "  #endif\n"
                         "#endif";
     simplecpp::DUI dui;
+#ifdef SIMPLECPP_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#endif
     dui.std = "c++17";
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
@@ -1592,7 +1598,11 @@ static void has_include_3()
     // Test file not found...
     ASSERT_EQUALS("\n\n\n\nB", preprocess(code, dui));
     // Unless -I is set (preferably, we should differentiate -I and -isystem...)
+#ifdef SIMPLECPP_SOURCE_DIR
+    dui.includePaths.push_back(std::string(SIMPLECPP_SOURCE_DIR) + "/testsuite");
+#else
     dui.includePaths.push_back("./testsuite");
+#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1608,6 +1618,9 @@ static void has_include_4()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
+#ifdef SIMPLECPP_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1623,6 +1636,9 @@ static void has_include_5()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "c++17";
+#ifdef SIMPLECPP_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }
@@ -1638,6 +1654,9 @@ static void has_include_6()
                         "#endif";
     simplecpp::DUI dui;
     dui.std = "gnu99";
+#ifdef SIMPLECPP_SOURCE_DIR
+    dui.includePaths.push_back(SIMPLECPP_SOURCE_DIR);
+#endif
     ASSERT_EQUALS("\n\nA", preprocess(code, dui));
     ASSERT_EQUALS("", preprocess(code));
 }


### PR DESCRIPTION
This pull request fixes the execution of the `testrunner` in out-of-source builds by setting the `SIMPLECPP_SOURCE_DIR` definition. This change ensures that the test runner can correctly find include paths by using the source directory.

The `CMakeLists.txt` file is updated to define `SIMPLECPP_SOURCE_DIR`, and the test cases in `test.cpp` are modified to conditionally add this directory to the include paths if 
defined.