### PR TITLE
refactor: modernize run-tests helpers with typing and safer subprocess handling

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -98,15 +98,9 @@ def run(compiler_executable: str, compiler_args: list[str]) -> tuple[int, str, s
   """Execute a compiler command and capture its exit code, stdout, and stderr."""
   cmd = [compiler_executable, *compiler_args]
 
-  try:
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8") as process:
-      stdout, stderr = process.communicate()
-      exit_code = process.returncode
-  except FileNotFoundError as e:
-    # Compiler not found
-    return (127, "", f"{e}")
-  except Exception as e:
-    return (1, "", f"{e}")
+  with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8") as process:
+    stdout, stderr = process.communicate()
+    exit_code = process.returncode
 
   output = cleanup(stdout)
   error = (stderr or "").strip()

--- a/run-tests.py
+++ b/run-tests.py
@@ -9,7 +9,7 @@ import sys
 
 def cleanup(out: str) -> str:
   parts = []
-  for line in out.decode('utf-8').splitlines():
+  for line in out.splitlines():
     if len(line) > 1 and line[0] == '#':
       continue
     parts.append("".join(line.split()))
@@ -99,7 +99,7 @@ def run(compiler_executable: str, compiler_args: list[str]) -> tuple[int, str, s
   cmd = [compiler_executable, *compiler_args]
 
   try:
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8") as process:
       stdout, stderr = process.communicate()
       exit_code = process.returncode
   except FileNotFoundError as e:
@@ -108,8 +108,8 @@ def run(compiler_executable: str, compiler_args: list[str]) -> tuple[int, str, s
   except Exception as e:
     return (1, "", f"{e}")
 
-  output = cleanup(stdout)  # bytes -> str via cleanup
-  error = (stderr or b"").decode("utf-8", errors="replace").strip()
+  output = cleanup(stdout)
+  error = (stderr or "").strip()
   return (exit_code, output, error)
 
 

--- a/run-tests.py
+++ b/run-tests.py
@@ -116,9 +116,9 @@ for cmd in commands:
     numberOfSkipped = numberOfSkipped + 1
     continue
 
-  clang_output = run(CLANG_EXE, cmd.split(' '))[1]
+  _, clang_output, _ = run(CLANG_EXE, cmd.split(' '))
 
-  gcc_output = run(GCC_EXE, cmd.split(' '))[1]
+  _, gcc_output, _ = run(GCC_EXE, cmd.split(' '))
 
   # -E is not supported and we bail out on unknown options
   simplecpp_ec, simplecpp_output, simplecpp_err = run(SIMPLECPP_EXE, cmd.replace('-E ', '', 1).split(' '))

--- a/run-tests.py
+++ b/run-tests.py
@@ -1,6 +1,7 @@
 
 import glob
 import os
+import shutil
 import subprocess
 import sys
 
@@ -12,6 +13,19 @@ def cleanup(out):
     s = "".join(s.split())
     ret = ret + s
   return ret
+
+
+# Check for required compilers and exit if any are missing
+CLANG_EXE = shutil.which('clang')
+if not CLANG_EXE:
+  sys.exit('Failed to run tests: clang compiler not found')
+
+GCC_EXE = shutil.which('gcc')
+if not GCC_EXE:
+  sys.exit('Failed to run tests: gcc compiler not found')
+
+SIMPLECPP_EXE = './simplecpp'
+
 
 commands = []
 
@@ -102,12 +116,12 @@ for cmd in commands:
     numberOfSkipped = numberOfSkipped + 1
     continue
 
-  clang_output = run('clang', cmd.split(' '))[1]
+  clang_output = run(CLANG_EXE, cmd.split(' '))[1]
 
-  gcc_output = run('gcc', cmd.split(' '))[1]
+  gcc_output = run(GCC_EXE, cmd.split(' '))[1]
 
   # -E is not supported and we bail out on unknown options
-  simplecpp_ec, simplecpp_output, simplecpp_err = run('./simplecpp', cmd.replace('-E ', '', 1).split(' '))
+  simplecpp_ec, simplecpp_output, simplecpp_err = run(SIMPLECPP_EXE, cmd.replace('-E ', '', 1).split(' '))
 
   if simplecpp_output != clang_output and simplecpp_output != gcc_output:
     filename = cmd[cmd.rfind('/')+1:]


### PR DESCRIPTION
This improves the `run-tests.py` script by adding type annotations and enhancing subprocess handling for better safety and readability.

----


> [!IMPORTANT]
> This pull request should be rebased & integrated *only* after the pull requests referenced below are themselves reviewed & integrated:
> * https://github.com/danmar/simplecpp/pull/509

