### PR TITLE
style: Format sources using astyle 3.0.1

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -761,18 +761,18 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
             while (stream.good() && ch != '\n') {
                 currentToken += ch;
                 ch = stream.readChar();
-                if(ch == '\\') {
+                if (ch == '\\') {
                     TokenString tmp;
                     char tmp_ch = ch;
-                    while((stream.good()) && (tmp_ch == '\\' || tmp_ch == ' ' || tmp_ch == '\t')) {
+                    while ((stream.good()) && (tmp_ch == '\\' || tmp_ch == ' ' || tmp_ch == '\t')) {
                         tmp += tmp_ch;
                         tmp_ch = stream.readChar();
                     }
-                    if(!stream.good()) {
+                    if (!stream.good()) {
                         break;
                     }
 
-                    if(tmp_ch != '\n') {
+                    if (tmp_ch != '\n') {
                         currentToken += tmp;
                     } else {
                         const TokenString check_portability = currentToken + tmp;

--- a/test.cpp
+++ b/test.cpp
@@ -438,14 +438,14 @@ static void comment_multiline()
     ASSERT_EQUALS("\n\nvoid f ( ) {", preprocess(code));
 
     const char code1[] = "#define ABC {// \\\r\n"
-                        "}\n"
-                        "void f() ABC\n";
+                         "}\n"
+                         "void f() ABC\n";
     ASSERT_EQUALS("\n\nvoid f ( ) {", preprocess(code1));
 
     const char code2[] = "#define A 1// \\\r"
-                        "\r"
-                        "2\r"
-                        "A\r";
+                         "\r"
+                         "2\r"
+                         "A\r";
     ASSERT_EQUALS("\n\n2\n1", preprocess(code2));
 
     const char code3[] = "void f() {// \\ \n}\n";
@@ -2100,7 +2100,7 @@ static void circularInclude()
             "#define TEST_H\n"
             "#include \"a/a.h\"\n"
             "#endif\n"
-        ;
+            ;
         cache.insert({path, makeTokenList(code, files, path)});
     }
 
@@ -2111,7 +2111,7 @@ static void circularInclude()
             "#define A_H\n"
             "#include \"../test.h\"\n"
             "#endif\n"
-        ;
+            ;
         cache.insert({path, makeTokenList(code, files, path)});
     }
 
@@ -3176,7 +3176,8 @@ static void fuzz_crash()
                             "n\n";
         (void)preprocess(code, simplecpp::DUI()); // do not crash
     }
-    { // #346
+    {
+        // #346
         const char code[] = "#define foo(intp)f##oo(intp\n"
                             "foo(f##oo(intp))\n";
         (void)preprocess(code, simplecpp::DUI()); // do not crash


### PR DESCRIPTION
This pull request reformats the codebase using **astyle 3.0.1** to ensure consistency with the project’s current style guidelines.

### Context

As noted in the review (https://github.com/danmar/simplecpp/pull/508#issuecomment-3234137957), the long-term plan is to transition formatting to **uncrustify** (likely by adapting the `runformat` script from the cppcheck repo). While that transition is being worked out, this change helps keep the repository consistent and avoids confusion for contributors.