### PR TITLE
CI-unixish.yml: cleaned up prerequisites for `macos-*`

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -47,11 +47,6 @@ jobs:
       run: |
         brew install coreutils
 
-    - name: Install missing software on macos
-      if: contains(matrix.os, 'macos')
-      run: |
-        brew install python3
-
     - name: Install missing Python packages
       run: |
         python3 -m pip config set global.break-system-packages true


### PR DESCRIPTION
```
/Users/runner/work/_temp/20baaeee-185a-44ce-ade0-b85e60ec6da4.sh: line 1: nproc: command not found
```

```
build (macos-15, clang++)python@3.13 3.13.7 is already installed and up-to-date. To reinstall 3.13.7, run: brew reinstall python@3.13
```
```
build (macos-14, clang++)python@3.13 3.13.7 is already installed and up-to-date. To reinstall 3.13.7, run: brew reinstall python@3.13
```
```
build (macos-13, clang++)python@3.13 3.13.7 is already installed and up-to-date. To reinstall 3.13.7, run: brew reinstall python@3.13
```