### PR TITLE
improved and exposed `isAbsolutePath()`

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2442,11 +2442,19 @@ namespace simplecpp {
     bool isAbsolutePath(const std::string &path)
     {
 #ifdef SIMPLECPP_WINDOWS
-        if (path.length() >= 3 && path[0] > 0 && std::isalpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/'))
+        // C:\\path\\file
+        // C:/path/file
+        if (path.length() >= 3 && std::isalpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/'))
             return true;
-        return path.length() > 1U && (path[0] == '/' || path[0] == '\\');
+
+        // \\host\path\file
+        // //host/path/file
+        if (path.length() >= 2 && (path[0] == '\\' || path[0] == '/') && (path[1] == '\\' || path[1] == '/'))
+            return true;
+
+        return false;
 #else
-        return path.length() > 1U && path[0] == '/';
+        return !path.empty() && path[0] == '/';
 #endif
     }
 }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -2438,21 +2438,18 @@ namespace simplecpp {
         return windowsPath;
     }
 #endif
-}
 
+    bool isAbsolutePath(const std::string &path)
+    {
 #ifdef SIMPLECPP_WINDOWS
-static bool isAbsolutePath(const std::string &path)
-{
-    if (path.length() >= 3 && path[0] > 0 && std::isalpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/'))
-        return true;
-    return path.length() > 1U && (path[0] == '/' || path[0] == '\\');
-}
+        if (path.length() >= 3 && path[0] > 0 && std::isalpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/'))
+            return true;
+        return path.length() > 1U && (path[0] == '/' || path[0] == '\\');
 #else
-static bool isAbsolutePath(const std::string &path)
-{
-    return path.length() > 1U && path[0] == '/';
-}
+        return path.length() > 1U && path[0] == '/';
 #endif
+    }
+}
 
 namespace simplecpp {
     /**
@@ -3013,7 +3010,7 @@ static std::string openHeaderDirect(std::ifstream &f, const std::string &path)
 
 static std::string openHeader(std::ifstream &f, const simplecpp::DUI &dui, const std::string &sourcefile, const std::string &header, bool systemheader)
 {
-    if (isAbsolutePath(header))
+    if (simplecpp::isAbsolutePath(header))
         return openHeaderDirect(f, simplecpp::simplifyPath(header));
 
     // prefer first to search the header relatively to source file if found, when not a system header

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -556,6 +556,9 @@ namespace simplecpp {
     /** Returns the __cplusplus value for a given standard */
     SIMPLECPP_LIB std::string getCppStdString(const std::string &std);
     SIMPLECPP_LIB std::string getCppStdString(cppstd_t std);
+
+    /** Checks if given path is absolute */
+    SIMPLECPP_LIB bool isAbsolutePath(const std::string &path);
 }
 
 #undef SIMPLECPP_TOKENLIST_ALLOW_PTR

--- a/test.cpp
+++ b/test.cpp
@@ -45,7 +45,7 @@ static int assertEquals(const std::string &expected, const std::string &actual, 
     if (expected != actual) {
         numberOfFailedAssertions++;
         std::cerr << "------ assertion failed ---------" << std::endl;
-        std::cerr << "line " << line << std::endl;
+        std::cerr << "line test.cpp:" << line << std::endl;
         std::cerr << "expected:" << pprint(expected) << std::endl;
         std::cerr << "actual:" << pprint(actual) << std::endl;
     }

--- a/test.cpp
+++ b/test.cpp
@@ -3246,6 +3246,26 @@ static void safe_api()
 #endif
 }
 
+static void isAbsolutePath() {
+#ifdef _WIN32
+    ASSERT_EQUALS(true, simplecpp::isAbsolutePath("C:\\foo\\bar"));
+    ASSERT_EQUALS(true, simplecpp::isAbsolutePath("C:/foo/bar"));
+    ASSERT_EQUALS(true, simplecpp::isAbsolutePath("\\\\foo\\bar"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo\\bar"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo/bar"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo.cpp"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("C:foo.cpp"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("C:foo\\bar.cpp"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("bar.cpp"));
+    //ASSERT_EQUALS(true, simplecpp::isAbsolutePath("\\")); // TODO
+#else
+    ASSERT_EQUALS(true, simplecpp::isAbsolutePath("/foo/bar"));
+    //ASSERT_EQUALS(true, simplecpp::isAbsolutePath("/")); // TODO
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo/bar"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo.cpp"));
+#endif
+}
+
 // crashes detected by fuzzer
 static void fuzz_crash()
 {
@@ -3524,6 +3544,8 @@ int main(int argc, char **argv)
     TEST_CASE(preprocess_files);
 
     TEST_CASE(safe_api);
+
+    TEST_CASE(isAbsolutePath);
 
     TEST_CASE(fuzz_crash);
 

--- a/test.cpp
+++ b/test.cpp
@@ -3251,6 +3251,7 @@ static void isAbsolutePath() {
     ASSERT_EQUALS(true, simplecpp::isAbsolutePath("C:\\foo\\bar"));
     ASSERT_EQUALS(true, simplecpp::isAbsolutePath("C:/foo/bar"));
     ASSERT_EQUALS(true, simplecpp::isAbsolutePath("\\\\foo\\bar"));
+
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo\\bar"));
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo/bar"));
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo.cpp"));
@@ -3258,11 +3259,23 @@ static void isAbsolutePath() {
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("C:foo\\bar.cpp"));
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("bar.cpp"));
     //ASSERT_EQUALS(true, simplecpp::isAbsolutePath("\\")); // TODO
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("0:\\foo\\bar"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("0:/foo/bar"));
+    //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("\\foo\\bar")); // TODO
+    //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("\\\\")); // TODO
+    //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("//")); // TODO
+    //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("/foo/bar")); // TODO
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("/"));
 #else
     ASSERT_EQUALS(true, simplecpp::isAbsolutePath("/foo/bar"));
     //ASSERT_EQUALS(true, simplecpp::isAbsolutePath("/")); // TODO
+    ASSERT_EQUALS(true, simplecpp::isAbsolutePath("//host/foo/bar"));
+
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo/bar"));
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo.cpp"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("C:\\foo\\bar"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("C:/foo/bar"));
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("\\\\foo\\bar"));
 #endif
 }
 

--- a/test.cpp
+++ b/test.cpp
@@ -3261,14 +3261,14 @@ static void isAbsolutePath() {
     //ASSERT_EQUALS(true, simplecpp::isAbsolutePath("\\")); // TODO
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("0:\\foo\\bar"));
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("0:/foo/bar"));
-    //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("\\foo\\bar")); // TODO
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("\\foo\\bar"));
     //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("\\\\")); // TODO
     //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("//")); // TODO
-    //ASSERT_EQUALS(false, simplecpp::isAbsolutePath("/foo/bar")); // TODO
+    ASSERT_EQUALS(false, simplecpp::isAbsolutePath("/foo/bar"));
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("/"));
 #else
     ASSERT_EQUALS(true, simplecpp::isAbsolutePath("/foo/bar"));
-    //ASSERT_EQUALS(true, simplecpp::isAbsolutePath("/")); // TODO
+    ASSERT_EQUALS(true, simplecpp::isAbsolutePath("/"));
     ASSERT_EQUALS(true, simplecpp::isAbsolutePath("//host/foo/bar"));
 
     ASSERT_EQUALS(false, simplecpp::isAbsolutePath("foo/bar"));


### PR DESCRIPTION
This is implemented in Cppcheck and simplecpp but their behavior differs. So this places a single (and improved) implementation in simplecpp for both to use.