### PR TITLE
enabled `clang-analyzer-*` clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,11 @@
 ---
 Checks: >
         *,
+        clang-analyzer-*,
         -abseil-*,
         -altera-*,
         -android-*,
         -cert-*,
-        -clang-analyzer-*,
         -cppcoreguidelines-*,
         -fuchsia-*,
         -google-*,


### PR DESCRIPTION
explicitly enable them because they will be disabled by default in a future version