### PR TITLE
Fix #581 (Failure when header is included twice with different macros defined)

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3701,12 +3701,11 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
                     else
                         ifstates.push(conditionIsTrue ? True : ElseIsTrue);
                     iftokens.push(rawtok);
-                } else if (ifstates.top() == True) {
-                    ifstates.top() = AlwaysFalse;
-                    iftokens.top()->nextcond = rawtok;
-                    iftokens.top() = rawtok;
-                } else if (ifstates.top() == ElseIsTrue && conditionIsTrue) {
-                    ifstates.top() = True;
+                } else {
+                    if (ifstates.top() == True)
+                        ifstates.top() = AlwaysFalse;
+                    else if (ifstates.top() == ElseIsTrue && conditionIsTrue)
+                        ifstates.top() = True;
                     iftokens.top()->nextcond = rawtok;
                     iftokens.top() = rawtok;
                 }


### PR DESCRIPTION
There was a regression introduced by #468 . This PR just reverts the #468 changes and introduces a test.