### PR TITLE
optimized `std::stack` usage in `simplecpp::TokenList::combineOperators()`

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1031,7 +1031,7 @@ static bool isAlternativeAndBitandBitor(const simplecpp::Token* tok)
 
 void simplecpp::TokenList::combineOperators()
 {
-    std::stack<bool> executableScope;
+    std::stack<bool, std::vector<bool>> executableScope;
     executableScope.push(false);
     for (Token *tok = front(); tok; tok = tok->next) {
         if (tok->op == '{') {

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1031,8 +1031,7 @@ static bool isAlternativeAndBitandBitor(const simplecpp::Token* tok)
 
 void simplecpp::TokenList::combineOperators()
 {
-    std::stack<bool, std::vector<bool>> executableScope;
-    executableScope.push(false);
+    std::stack<bool, std::vector<bool>> executableScope{{false}};
     for (Token *tok = front(); tok; tok = tok->next) {
         if (tok->op == '{') {
             if (executableScope.top()) {


### PR DESCRIPTION
- use `std::vector` as underlying container for `std::stack`
- initialize `std::stack` with initial value instead of inserting it