### PR TITLE
Add file load callback (fixes #667)

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3155,6 +3155,9 @@ std::pair<simplecpp::FileData *, bool> simplecpp::FileDataCache::tryload(FileDat
     mImpl->mIdMap.emplace(fileId, data);
     mData.emplace_back(data);
 
+    if (mLoadCallback)
+        mLoadCallback(*data);
+
     return {data, true};
 }
 

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -501,6 +501,10 @@ namespace simplecpp {
 
         using load_callback_type = std::function<void (FileData &)>;
 
+        void set_load_callback(load_callback_type cb) {
+            mLoadCallback = std::move(cb);
+        }
+
     private:
         struct Impl;
         std::unique_ptr<Impl> mImpl;

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <iosfwd>
 #include <list>
 #include <map>
@@ -498,6 +499,8 @@ namespace simplecpp {
             return mData.cend();
         }
 
+        using load_callback_type = std::function<void (FileData &)>;
+
     private:
         struct Impl;
         std::unique_ptr<Impl> mImpl;
@@ -508,6 +511,7 @@ namespace simplecpp {
 
         container_type mData;
         name_map_type mNameMap;
+        load_callback_type mLoadCallback;
     };
 
     /** Converts character literal (including prefix, but not ud-suffix) to long long value.


### PR DESCRIPTION
Adds a callback mechanism for file loading, needed for performance optimizations in cppcheck.