### PR TITLE
Fix #684: Keep line directives in tokenized output

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -648,6 +648,8 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
 
     const Token *oldLastToken = nullptr;
 
+    bool locationchange = false;
+
     Location location(fileIndex(filename), 1, 1);
     while (stream.good()) {
         unsigned char ch = stream.readChar();
@@ -716,6 +718,7 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
                 if (ppTok && ppTok->str()[0] == '\"')
                     location.fileIndex = fileIndex(replaceAll(ppTok->str().substr(1U, ppTok->str().size() - 2U),"\\\\","\\"));
 
+                locationchange = true;
             }
 
             continue;
@@ -933,6 +936,11 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
         }
 
         push_back(new Token(currentToken, location, !!std::isspace(stream.peekChar())));
+
+        if (locationchange) {
+            back()->locationchange = true;
+            locationchange = false;
+        }
 
         if (multiline)
             location.col += currentToken.size();
@@ -1435,7 +1443,7 @@ const simplecpp::Token* simplecpp::TokenList::lastLineTok(int maxsize) const
     const Token* prevTok = nullptr;
     int count = 0;
     for (const Token *tok = cback(); ; tok = tok->previous) {
-        if (!sameline(tok, cback()))
+        if (!sameline(tok, cback()) || tok->locationchange)
             break;
         if (tok->comment)
             continue;
@@ -2979,7 +2987,9 @@ static const simplecpp::Token *gotoNextLine(const simplecpp::Token *tok)
 {
     const unsigned int line = tok->location.line;
     const unsigned int file = tok->location.fileIndex;
-    while (tok && tok->location.line == line && tok->location.fileIndex == file)
+    if (tok)
+        tok = tok->next;
+    while (tok && tok->location.line == line && tok->location.fileIndex == file && !tok->locationchange)
         tok = tok->next;
     return tok;
 }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -3532,7 +3532,7 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
             continue;
         }
 
-        if (rawtok->op == '#' && !sameline(rawtok->previousSkipComments(), rawtok)) {
+        if (rawtok->op == '#' && (!sameline(rawtok->previousSkipComments(), rawtok) || rawtok->locationchange)) {
             if (!sameline(rawtok, rawtok->next)) {
                 rawtok = rawtok->next;
                 continue;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -640,23 +640,6 @@ static bool isStringLiteralPrefix(const std::string &str)
            str == "R" || str == "uR" || str == "UR" || str == "LR" || str == "u8R";
 }
 
-void simplecpp::TokenList::lineDirective(unsigned int fileIndex_, unsigned int line, Location &location)
-{
-    if (fileIndex_ != location.fileIndex || line >= location.line) {
-        location.fileIndex = fileIndex_;
-        location.line = line;
-        return;
-    }
-
-    if (line + 2 >= location.line) {
-        location.line = line;
-        while (cback()->op != '#')
-            deleteToken(back());
-        deleteToken(back());
-        return;
-    }
-}
-
 static const std::string COMMENT_END("*/");
 
 void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename, OutputList *outputList)
@@ -726,17 +709,13 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
                 if (!ppTok || !ppTok->number)
                     continue;
 
-                const unsigned int line = std::atol(ppTok->str().c_str());
+                location.line = std::atol(ppTok->str().c_str());
+
                 ppTok = advanceAndSkipComments(ppTok);
 
-                unsigned int fileindex;
-
                 if (ppTok && ppTok->str()[0] == '\"')
-                    fileindex = fileIndex(replaceAll(ppTok->str().substr(1U, ppTok->str().size() - 2U),"\\\\","\\"));
-                else
-                    fileindex = location.fileIndex;
+                    location.fileIndex = fileIndex(replaceAll(ppTok->str().substr(1U, ppTok->str().size() - 2U),"\\\\","\\"));
 
-                lineDirective(fileindex, line, location);
             }
 
             continue;

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1443,8 +1443,10 @@ const simplecpp::Token* simplecpp::TokenList::lastLineTok(int maxsize) const
     const Token* prevTok = nullptr;
     int count = 0;
     for (const Token *tok = cback(); ; tok = tok->previous) {
-        if (!sameline(tok, cback()) || tok->locationchange)
+        if (!sameline(tok, cback()))
             break;
+        if (tok->locationchange)
+            return tok;
         if (tok->comment)
             continue;
         if (++count > maxsize)

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -151,12 +151,12 @@ namespace simplecpp {
     class SIMPLECPP_LIB Token {
     public:
         Token(const TokenString &s, const Location &loc, bool wsahead = false) :
-            whitespaceahead(wsahead), location(loc), string(s) {
+            whitespaceahead(wsahead), locationchange(false), location(loc), string(s) {
             flags();
         }
 
         Token(const Token &tok) :
-            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), whitespaceahead(tok.whitespaceahead), location(tok.location), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {}
+            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), whitespaceahead(tok.whitespaceahead), locationchange(tok.locationchange), location(tok.location), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {}
 
         Token &operator=(const Token &tok) = delete;
 
@@ -182,6 +182,7 @@ namespace simplecpp {
         bool name;
         bool number;
         bool whitespaceahead;
+        bool locationchange; /* token location is at a discontinuity from #line directive */
         Location location;
         Token *previous{};
         Token *next{};

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -151,7 +151,7 @@ namespace simplecpp {
     class SIMPLECPP_LIB Token {
     public:
         Token(const TokenString &s, const Location &loc, bool wsahead = false) :
-            whitespaceahead(wsahead), locationchange(false), location(loc), string(s) {
+            whitespaceahead(wsahead), location(loc), string(s) {
             flags();
         }
 
@@ -182,7 +182,8 @@ namespace simplecpp {
         bool name;
         bool number;
         bool whitespaceahead;
-        bool locationchange; /* token location is at a discontinuity from #line directive */
+        /** whether token location is at a discontinuity from a #line directive */
+        bool locationchange {false};
         Location location;
         Token *previous{};
         Token *next{};

--- a/simplecpp.h
+++ b/simplecpp.h
@@ -396,7 +396,6 @@ namespace simplecpp {
         void constFoldQuestionOp(Token *&tok1);
 
         std::string readUntil(Stream &stream, const Location &location, char start, char end, OutputList *outputList);
-        void lineDirective(unsigned int fileIndex_, unsigned int line, Location &location);
 
         const Token* lastLineTok(int maxsize=1000) const;
         const Token* isLastLinePreprocessor(int maxsize=1000) const;

--- a/test.cpp
+++ b/test.cpp
@@ -2481,9 +2481,9 @@ static void location12()
         "/**//**/#/**//**/line/**//**/3/**//**/\"file.c\"/**/\n"
         "__LINE__ __FILE__\n";
     ASSERT_EQUALS("\n"
-                  "#line 3 \"file.c\"\n"
-                  "3 \"file.c\"",
-                  preprocess(code));
+        "#line 3 \"file.c\"\n"
+        "3 \"file.c\"",
+        preprocess(code));
 }
 
 static void missingHeader1()
@@ -2747,6 +2747,62 @@ static void nullDirective3()
                         "x = a;\n";
 
     ASSERT_EQUALS("\n\n\n\nx = 1 ;", preprocess(code));
+}
+
+static void lineDirective1()
+{
+    const char code[] = "#line 1\n"
+                        "#line 2 \"header1.h\"\n"
+                        "# 1\n"
+                        "# 2 \"header2.h\"\n"
+                        "# 3 \"header2.h\" 0\n";
+
+    std::vector<std::string> files;
+    const simplecpp::TokenList rawtokens(code, files);
+
+    ASSERT_EQUALS("1: # line 1 # line 2 \"header1.h\"\n"
+                  "#line 2 \"header1.h\"\n"
+                  "2: # 1\n"
+                  "#line 1 \"header1.h\"\n"
+                  "1: # 2 \"header2.h\"\n"
+                  "#line 2 \"header2.h\"\n"
+                  "2: # 3 \"header2.h\" 0",
+                  rawtokens.stringify(true));
+
+    simplecpp::FileDataCache cache;
+    simplecpp::TokenList out(files);
+    simplecpp::DUI dui;
+    simplecpp::preprocess(out, rawtokens, files, cache, dui);
+
+    ASSERT_EQUALS("", out.stringify(true));
+}
+
+static void lineDirective2()
+{
+    const char code[] = "#\n"
+                        "#line 1\n"
+                        "include\n"
+                        "#line 1\n"
+                        "\"header1.h\"\n";
+
+    std::vector<std::string> files;
+    const simplecpp::TokenList rawtokens(code, files);
+
+    ASSERT_EQUALS("1: #\n"
+                  "2: # line 1\n"
+                  "#line 1 \"\"\n"
+                  "1: include\n"
+                  "2: # line 1\n"
+                  "#line 1 \"\"\n"
+                  "1: \"header1.h\"",
+                  rawtokens.stringify(true));
+
+    simplecpp::FileDataCache cache;
+    simplecpp::TokenList out(files);
+    simplecpp::DUI dui;
+    simplecpp::preprocess(out, rawtokens, files, cache, dui);
+
+    ASSERT_EQUALS("1: include \"header1.h\"", out.stringify(true));
 }
 
 static void include1()
@@ -4166,6 +4222,9 @@ static void runTests(int argc, char **argv, Input input)
     TEST_CASE(nullDirective1);
     TEST_CASE(nullDirective2);
     TEST_CASE(nullDirective3);
+
+    TEST_CASE(lineDirective1);
+    TEST_CASE(lineDirective2);
 
     TEST_CASE(include1);
     TEST_CASE(include2);

--- a/test.cpp
+++ b/test.cpp
@@ -2481,9 +2481,9 @@ static void location12()
         "/**//**/#/**//**/line/**//**/3/**//**/\"file.c\"/**/\n"
         "__LINE__ __FILE__\n";
     ASSERT_EQUALS("\n"
-        "#line 3 \"file.c\"\n"
-        "3 \"file.c\"",
-        preprocess(code));
+                  "#line 3 \"file.c\"\n"
+                  "3 \"file.c\"",
+                  preprocess(code));
 }
 
 static void missingHeader1()

--- a/test.cpp
+++ b/test.cpp
@@ -2771,7 +2771,7 @@ static void lineDirective1()
 
     simplecpp::FileDataCache cache;
     simplecpp::TokenList out(files);
-    simplecpp::DUI dui;
+    const simplecpp::DUI dui;
     simplecpp::preprocess(out, rawtokens, files, cache, dui);
 
     ASSERT_EQUALS("", out.stringify(true));
@@ -2799,7 +2799,7 @@ static void lineDirective2()
 
     simplecpp::FileDataCache cache;
     simplecpp::TokenList out(files);
-    simplecpp::DUI dui;
+    const simplecpp::DUI dui;
     simplecpp::preprocess(out, rawtokens, files, cache, dui);
 
     ASSERT_EQUALS("1: include \"header1.h\"", out.stringify(true));


### PR DESCRIPTION
The `lineDirective` function is not really needed after this change and has been removed. A `locationchange` flag has been added to the `Token` class to keep track of when a location discontinuity occurs, this is needed for `gotoNextLine` to still work correctly during preprocessing when `#line` moves back to the same line it is already at.