### PR TITLE
Improve no_eof_newline warning

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -277,14 +277,7 @@ int main(int argc, char **argv)
                 break;
             case simplecpp::Output::PORTABILITY_BACKSLASH:
             case simplecpp::Output::PORTABILITY_LINE_DIRECTIVE:
-                std::cerr << "portability: ";
-                break;
             case simplecpp::Output::PORTABILITY_NO_EOF_NEWLINE:
-                if (simplecpp::getCStd(dui.std) == simplecpp::CUnknown) {
-                    // Only UB for c code, suppress for c++ code
-                    // If no standard is specified then prefer to have a false negative
-                    continue;
-                }
                 std::cerr << "portability: ";
                 break;
             case simplecpp::Output::UNHANDLED_CHAR_ERROR:

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1022,11 +1022,11 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
             location.adjust(currentToken);
     }
 
-    if (!trailing_nl && outputList) {
+    if ((cstd != CUnknown || (cstd == CUnknown && cppstd == CPPUnknown)) && !trailing_nl && outputList) {
         Output err{
             Output::PORTABILITY_NO_EOF_NEWLINE,
             location,
-            "No newline at end of file."
+            "No newline at end of file is undefined behavior in C."
         };
         outputList->emplace_back(std::move(err));
     }

--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1022,7 +1022,7 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
             location.adjust(currentToken);
     }
 
-    if ((cstd != CUnknown || (cstd == CUnknown && cppstd == CPPUnknown)) && !trailing_nl && outputList) {
+    if ((cstd != CUnknown || cppstd == CPPUnknown) && !trailing_nl && outputList) {
         Output err{
             Output::PORTABILITY_NO_EOF_NEWLINE,
             location,

--- a/test.cpp
+++ b/test.cpp
@@ -3480,13 +3480,21 @@ static void readfile_no_eof_newline()
         const char code[] = "\\\n";
         simplecpp::OutputList outputList;
         readfile(code, sizeof(code)-1, {}, &outputList);
-        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file.\n", toString(outputList));
+        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file is undefined behavior in C.\n", toString(outputList));
+    }
+    {
+        const char code[] = "\\\n";
+        simplecpp::DUI dui;
+        dui.std = "c++03";
+        simplecpp::OutputList outputList;
+        readfile(code, sizeof(code)-1, dui, &outputList);
+        ASSERT_EQUALS("", toString(outputList));
     }
     {
         const char code[] = "#define A";
         simplecpp::OutputList outputList;
         readfile(code, sizeof(code)-1, {}, &outputList);
-        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file.\n", toString(outputList));
+        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file is undefined behavior in C.\n", toString(outputList));
     }
     {
         const char code[] = "#define A\n";
@@ -3498,13 +3506,13 @@ static void readfile_no_eof_newline()
         const char code[] = "#define A\\";
         simplecpp::OutputList outputList;
         readfile(code, sizeof(code)-1, {}, &outputList);
-        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file.\n", toString(outputList));
+        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file is undefined behavior in C.\n", toString(outputList));
     }
     {
         const char code[] = "// comment";
         simplecpp::OutputList outputList;
         readfile(code, sizeof(code)-1, {}, &outputList);
-        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file.\n", toString(outputList));
+        ASSERT_EQUALS("file0,1,portability_no_eof_newline,No newline at end of file is undefined behavior in C.\n", toString(outputList));
     }
     {
         const char code[] = "// comment\n";
@@ -3516,7 +3524,7 @@ static void readfile_no_eof_newline()
         const char code[] = "/* comment \n comment */";
         simplecpp::OutputList outputList;
         readfile(code, sizeof(code)-1, {}, &outputList);
-        ASSERT_EQUALS("file0,2,portability_no_eof_newline,No newline at end of file.\n", toString(outputList));
+        ASSERT_EQUALS("file0,2,portability_no_eof_newline,No newline at end of file is undefined behavior in C.\n", toString(outputList));
     }
     {
         const char code[] = "/* comment \n comment */\n";


### PR DESCRIPTION
This is an addendum to #672. Use `DUI::std` to decide if a warning should be produced, clarify error message, add more tests.