### PR TITLE
Add newline to macro def string before tokenizing

### DIFF
--- a/simplecpp.cpp
+++ b/simplecpp.cpp
@@ -1595,7 +1595,7 @@ namespace simplecpp {
          * @throws std::runtime_error thrown on bad macro syntax
          */
         Macro(const std::string &name, const std::string &value, std::vector<std::string> &f) : nameTokDef(nullptr), files(f), tokenListDefine(f), valueDefinedInCode_(false) {
-            const std::string def(name + ' ' + value);
+            const std::string def(name + ' ' + value + '\n');
             StdCharBufStream stream(reinterpret_cast<const unsigned char*>(def.data()), def.size());
             tokenListDefine.readfile(stream);
             if (!parseDefine(tokenListDefine.cfront()))


### PR DESCRIPTION
This isn't an issue at the moment because the Macro constructor discards any tokenization errors, but I think it's good to make sure that anything sent to readfile has an ending newline to prevent any future issues.